### PR TITLE
Update bindings to use new Api extensions and rename Rect3->AABB

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -684,7 +684,7 @@ def is_core_type(name):
                   "PoolColorArray",
                   "Quat",
                   "Rect2",
-                  "Rect3",
+                  "AABB",
                   "RID",
                   "String",
                   "Transform",
@@ -713,7 +713,8 @@ def escape_cpp(name):
         "switch":   "_switch",
         "export":   "_export",
         "template": "_template",
-        "new":      "new_"
+        "new":      "new_",
+        "operator": "_operator"
     }
     if name in escapes:
         return escapes[name]

--- a/include/core/AABB.hpp
+++ b/include/core/AABB.hpp
@@ -1,5 +1,5 @@
-#ifndef RECT3_H
-#define RECT3_H
+#ifndef AABB_H
+#define AABB_H
 
 #include "Vector3.hpp"
 
@@ -9,7 +9,7 @@
 
 namespace godot {
 
-class Rect3 {
+class AABB {
 public:
 	Vector3 pos;
 	Vector3 size;
@@ -31,16 +31,16 @@ public:
 	inline void set_size(const Vector3& p_size) { size=p_size; }
 
 
-	bool operator==(const Rect3& p_rval) const;
-	bool operator!=(const Rect3& p_rval) const;
+	bool operator==(const AABB& p_rval) const;
+	bool operator!=(const AABB& p_rval) const;
 
-	bool intersects(const Rect3& p_aabb) const; /// Both AABBs overlap
-	bool intersects_inclusive(const Rect3& p_aabb) const; /// Both AABBs (or their faces) overlap
-	bool encloses(const Rect3 & p_aabb) const; /// p_aabb is completely inside this
+	bool intersects(const AABB& p_aabb) const; /// Both AABBs overlap
+	bool intersects_inclusive(const AABB& p_aabb) const; /// Both AABBs (or their faces) overlap
+	bool encloses(const AABB & p_aabb) const; /// p_aabb is completely inside this
 
-	Rect3 merge(const Rect3& p_with) const;
-	void merge_with(const Rect3& p_aabb); ///merge with another AABB
-	Rect3 intersection(const Rect3& p_aabb) const; ///get box where two intersect, empty if no intersection occurs
+	AABB merge(const AABB& p_with) const;
+	void merge_with(const AABB& p_aabb); ///merge with another AABB
+	AABB intersection(const AABB& p_aabb) const; ///get box where two intersect, empty if no intersection occurs
 	bool intersects_segment(const Vector3& p_from, const Vector3& p_to,Vector3* r_clip=NULL,Vector3* r_normal=NULL) const;
 	bool intersects_ray(const Vector3& p_from, const Vector3& p_dir,Vector3* r_clip=NULL,Vector3* r_normal=NULL) const;
 	bool smits_intersect_ray(const Vector3 &from,const Vector3& p_dir, real_t t0, real_t t1) const;
@@ -60,20 +60,20 @@ public:
 	int get_shortest_axis_index() const;
 	real_t get_shortest_axis_size() const;
 
-	Rect3 grow(real_t p_by) const;
+	AABB grow(real_t p_by) const;
 	void grow_by(real_t p_amount);
 
 	void get_edge(int p_edge,Vector3& r_from,Vector3& r_to) const;
 	Vector3 get_endpoint(int p_point) const;
 
-	Rect3 expand(const Vector3& p_vector) const;
+	AABB expand(const Vector3& p_vector) const;
 	void project_range_in_plane(const Plane& p_plane,real_t &r_min,real_t& r_max) const;
 	void expand_to(const Vector3& p_vector); /** expand to contain a point if necesary */
 
 	operator String() const;
 
-	inline Rect3() {}
-	inline Rect3(const Vector3 &p_pos,const Vector3& p_size) { pos=p_pos; size=p_size; }
+	inline AABB() {}
+	inline AABB(const Vector3 &p_pos,const Vector3& p_size) { pos=p_pos; size=p_size; }
 
 
 };

--- a/include/core/CoreTypes.hpp
+++ b/include/core/CoreTypes.hpp
@@ -3,6 +3,7 @@
 
 #include "Defs.hpp"
 
+#include "AABB.hpp"
 #include "Array.hpp"
 #include "Basis.hpp"
 #include "Color.hpp"
@@ -12,7 +13,6 @@
 #include "PoolArrays.hpp"
 #include "Quat.hpp"
 #include "Rect2.hpp"
-#include "Rect3.hpp"
 #include "RID.hpp"
 #include "String.hpp"
 #include "Transform.hpp"

--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -87,7 +87,7 @@ typedef float real_t;
 
 
 #ifndef ERR_PRINT
-#define ERR_PRINT(msg) fprintf(stderr, "ERROR: %s\n", (msg).c_string())
+#define ERR_PRINT(msg) fprintf(stderr, "ERROR: %S\n", (msg).unicode_str())
 #endif
 
 #ifndef ERR_FAIL_INDEX_V

--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -86,7 +86,7 @@ struct _ArgCast<Variant> {
 template<class T>
 T *as(Object *obj)
 {
-	return (T *) godot::api->godot_nativescript_get_userdata(obj);
+	return (T *) godot::nativescript_api->godot_nativescript_get_userdata(obj);
 }
 
 // instance and destroy funcs
@@ -118,7 +118,7 @@ void register_class()
 	destroy.destroy_func = _godot_class_destroy_func<T>;
 
 
-	godot::api->godot_nativescript_register_class(godot::_RegisterState::nativescript_handle, T::___get_type_name(), T::___get_base_type_name(), create, destroy);
+	godot::nativescript_api->godot_nativescript_register_class(godot::_RegisterState::nativescript_handle, T::___get_type_name(), T::___get_base_type_name(), create, destroy);
 	T::_register_methods();
 }
 
@@ -132,7 +132,7 @@ void register_tool_class()
 	destroy.destroy_func = _godot_class_destroy_func<T>;
 
 
-	godot::api->godot_nativescript_register_tool_class(godot::_RegisterState::nativescript_handle, T::___get_type_name(), T::___get_base_type_name(), create, destroy);
+	godot::nativescript_api->godot_nativescript_register_tool_class(godot::_RegisterState::nativescript_handle, T::___get_type_name(), T::___get_base_type_name(), create, destroy);
 	T::_register_methods();
 }
 
@@ -285,7 +285,7 @@ void register_method(const char *name, M method_ptr, godot_method_rpc_mode rpc_t
 	godot_method_attributes attr = {};
 	attr.rpc_type = rpc_type;
 
-	godot::api->godot_nativescript_register_method(godot::_RegisterState::nativescript_handle, ___get_method_class_name(method_ptr), name, attr, method);
+	godot::nativescript_api->godot_nativescript_register_method(godot::_RegisterState::nativescript_handle, ___get_method_class_name(method_ptr), name, attr, method);
 }
 
 
@@ -403,7 +403,7 @@ void register_property(const char *name, P (T::*var), P default_value, godot_met
 	get_func.free_func   = godot::api->godot_free;
 	get_func.get_func    = &_PropertyDefaultGetFunc<T, P>::_wrapped_getter;
 
-	godot::api->godot_nativescript_register_property(godot::_RegisterState::nativescript_handle, T::___get_type_name(), name, &attr, set_func, get_func);
+	godot::nativescript_api->godot_nativescript_register_property(godot::_RegisterState::nativescript_handle, T::___get_type_name(), name, &attr, set_func, get_func);
 }
 
 
@@ -437,7 +437,7 @@ void register_property(const char *name, void (T::*setter)(P), P (T::*getter)(),
 	get_func.free_func   = godot::api->godot_free;
 	get_func.get_func    = &_PropertyGetFunc<T, P>::_wrapped_getter;
 
-	godot::api->godot_nativescript_register_property(godot::_RegisterState::nativescript_handle, T::___get_type_name(), name, &attr, set_func, get_func);
+	godot::nativescript_api->godot_nativescript_register_property(godot::_RegisterState::nativescript_handle, T::___get_type_name(), name, &attr, set_func, get_func);
 
 }
 
@@ -466,7 +466,7 @@ void register_signal(String name, Dictionary args = Dictionary())
 		signal.args[i].type = args.values()[i];
 	}
 
-	godot::api->godot_nativescript_register_signal(godot::_RegisterState::nativescript_handle, T::___get_type_name(), &signal);
+	godot::nativescript_api->godot_nativescript_register_signal(godot::_RegisterState::nativescript_handle, T::___get_type_name(), &signal);
 
 	for (int i = 0; i < signal.num_args; i++) {
 		godot::api->godot_string_destroy(&signal.args[i].name);

--- a/include/core/GodotGlobal.hpp
+++ b/include/core/GodotGlobal.hpp
@@ -7,7 +7,8 @@
 
 namespace godot {
 
-extern "C" const godot_gdnative_api_struct *api;
+extern "C" const godot_gdnative_core_api_struct *api;
+extern "C" const godot_gdnative_ext_nativescript_api_struct *nativescript_api;
 
 class Godot {
 

--- a/include/core/NodePath.hpp
+++ b/include/core/NodePath.hpp
@@ -24,8 +24,6 @@ public:
 
 	int get_name_count() const;
 
-	String get_property() const;
-
 	String get_subname(const int idx) const;
 
 	int get_subname_count() const;

--- a/include/core/String.hpp
+++ b/include/core/String.hpp
@@ -41,6 +41,7 @@ public:
 
 	int length() const;
 	const wchar_t *unicode_str() const;
+	char *alloc_c_string() const;
 	void get_c_string(char *p_dest, int *p_size) const;
 
 	int64_t find(String p_what) const;

--- a/include/core/String.hpp
+++ b/include/core/String.hpp
@@ -40,7 +40,8 @@ public:
 	operator NodePath() const;
 
 	int length() const;
-	const char *c_string() const;
+	const wchar_t *unicode_str() const;
+	void get_c_string(char *p_dest, int *p_size) const;
 
 	int64_t find(String p_what) const;
 	int64_t find_from(String p_what, int64_t p_from) const;
@@ -106,6 +107,8 @@ public:
 };
 
 String operator+(const char *a, const String &b);
+String operator+(const wchar_t *a, const String &b);
+
 }
 
 #endif // STRING_H

--- a/include/core/Transform.hpp
+++ b/include/core/Transform.hpp
@@ -4,7 +4,7 @@
 #include "Basis.hpp"
 
 #include "Plane.hpp"
-#include "Rect3.hpp"
+#include "AABB.hpp"
 
 namespace godot {
 
@@ -53,8 +53,8 @@ public:
 	Plane xform(const Plane& p_plane) const;
 	Plane xform_inv(const Plane& p_plane) const;
 
-	Rect3 xform(const Rect3& p_aabb) const;
-	Rect3 xform_inv(const Rect3& p_aabb) const;
+	AABB xform(const AABB& p_aabb) const;
+	AABB xform_inv(const AABB& p_aabb) const;
 
 	void operator*=(const Transform& p_transform);
 	Transform operator*(const Transform& p_transform) const;

--- a/include/core/Variant.hpp
+++ b/include/core/Variant.hpp
@@ -5,6 +5,7 @@
 
 #include "Defs.hpp"
 
+#include "AABB.hpp"
 #include "Basis.hpp"
 #include "Color.hpp"
 #include "NodePath.hpp"
@@ -12,7 +13,6 @@
 #include "PoolArrays.hpp"
 #include "Quat.hpp"
 #include "Rect2.hpp"
-#include "Rect3.hpp"
 #include "RID.hpp"
 #include "String.hpp"
 #include "Transform.hpp"
@@ -154,7 +154,7 @@ public:
 	Variant(const Plane& p_plane);
 
 
-	Variant(const Rect3& p_aabb);
+	Variant(const AABB& p_aabb);
 
 	Variant(const Quat& p_quat);
 
@@ -215,7 +215,7 @@ public:
 	operator Rect2() const;
 	operator Vector3() const;
 	operator Plane() const;
-	operator Rect3() const;
+	operator AABB() const;
 	operator Quat() const;
 	operator Basis() const;
 	operator Transform() const;

--- a/src/core/AABB.cpp
+++ b/src/core/AABB.cpp
@@ -1,4 +1,4 @@
-#include "Rect3.hpp"
+#include "AABB.hpp"
 #include "Vector3.hpp"
 #include "Plane.hpp"
 
@@ -6,7 +6,7 @@
 
 namespace godot {
 
-bool Rect3::intersects(const Rect3& p_aabb) const {
+bool AABB::intersects(const AABB& p_aabb) const {
 
 	if ( pos.x >= (p_aabb.pos.x + p_aabb.size.x) )
 		return false;
@@ -24,7 +24,7 @@ bool Rect3::intersects(const Rect3& p_aabb) const {
 	return true;
 }
 
-bool Rect3::intersects_inclusive(const Rect3& p_aabb) const {
+bool AABB::intersects_inclusive(const AABB& p_aabb) const {
 
 	if ( pos.x > (p_aabb.pos.x + p_aabb.size.x) )
 		return false;
@@ -42,7 +42,7 @@ bool Rect3::intersects_inclusive(const Rect3& p_aabb) const {
 	return true;
 }
 
-bool Rect3::encloses(const Rect3 & p_aabb) const {
+bool AABB::encloses(const AABB & p_aabb) const {
 
 	Vector3 src_min=pos;
 	Vector3 src_max=pos+size;
@@ -59,7 +59,7 @@ bool Rect3::encloses(const Rect3 & p_aabb) const {
 
 }
 
-Vector3 Rect3::get_support(const Vector3& p_normal) const {
+Vector3 AABB::get_support(const Vector3& p_normal) const {
 
 	Vector3 half_extents = size * 0.5;
 	Vector3 ofs = pos + half_extents;
@@ -72,7 +72,7 @@ Vector3 Rect3::get_support(const Vector3& p_normal) const {
 }
 
 
-Vector3 Rect3::get_endpoint(int p_point) const {
+Vector3 AABB::get_endpoint(int p_point) const {
 
 	switch(p_point) {
 		case 0: return Vector3( pos.x	, pos.y		, pos.z		);
@@ -88,7 +88,7 @@ Vector3 Rect3::get_endpoint(int p_point) const {
 	ERR_FAIL_V(Vector3());
 }
 
-bool Rect3::intersects_convex_shape(const Plane *p_planes, int p_plane_count) const {
+bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count) const {
 
 	Vector3 half_extents = size * 0.5;
 	Vector3 ofs = pos + half_extents;
@@ -108,7 +108,7 @@ bool Rect3::intersects_convex_shape(const Plane *p_planes, int p_plane_count) co
 	return true;
 }
 
-bool Rect3::has_point(const Vector3& p_point) const {
+bool AABB::has_point(const Vector3& p_point) const {
 
 	if (p_point.x<pos.x)
 		return false;
@@ -127,7 +127,7 @@ bool Rect3::has_point(const Vector3& p_point) const {
 }
 
 
-void Rect3::expand_to(const Vector3& p_vector) {
+void AABB::expand_to(const Vector3& p_vector) {
 
 	Vector3 begin=pos;
 	Vector3 end=pos+size;
@@ -150,7 +150,7 @@ void Rect3::expand_to(const Vector3& p_vector) {
 	size=end-begin;
 }
 
-void Rect3::project_range_in_plane(const Plane& p_plane,real_t &r_min,real_t& r_max) const {
+void AABB::project_range_in_plane(const Plane& p_plane,real_t &r_min,real_t& r_max) const {
 
 	Vector3 half_extents( size.x * 0.5, size.y * 0.5, size.z * 0.5 );
 	Vector3 center( pos.x + half_extents.x, pos.y + half_extents.y, pos.z + half_extents.z );
@@ -161,7 +161,7 @@ void Rect3::project_range_in_plane(const Plane& p_plane,real_t &r_min,real_t& r_
 	r_max = distance + length;
 }
 
-real_t Rect3::get_longest_axis_size() const {
+real_t AABB::get_longest_axis_size() const {
 
 	real_t max_size=size.x;
 
@@ -176,7 +176,7 @@ real_t Rect3::get_longest_axis_size() const {
 	return max_size;
 }
 
-real_t Rect3::get_shortest_axis_size() const {
+real_t AABB::get_shortest_axis_size() const {
 
 	real_t max_size=size.x;
 
@@ -191,7 +191,7 @@ real_t Rect3::get_shortest_axis_size() const {
 	return max_size;
 }
 
-bool Rect3::smits_intersect_ray(const Vector3 &from,const Vector3& dir, real_t t0, real_t t1) const {
+bool AABB::smits_intersect_ray(const Vector3 &from,const Vector3& dir, real_t t0, real_t t1) const {
 
 	real_t divx=1.0/dir.x;
 	real_t divy=1.0/dir.y;
@@ -238,7 +238,7 @@ bool Rect3::smits_intersect_ray(const Vector3 &from,const Vector3& dir, real_t t
 	return ( (tmin < t1) && (tmax > t0) );
 }
 
-void Rect3::grow_by(real_t p_amount) {
+void AABB::grow_by(real_t p_amount) {
 
 	pos.x-=p_amount;
 	pos.y-=p_amount;
@@ -249,24 +249,24 @@ void Rect3::grow_by(real_t p_amount) {
 }
 
 
-real_t Rect3::get_area() const {
+real_t AABB::get_area() const {
 
 	return size.x*size.y*size.z;
 
 }
 
-bool Rect3::operator==(const Rect3& p_rval) const {
+bool AABB::operator==(const AABB& p_rval) const {
 
 	return ((pos==p_rval.pos) && (size==p_rval.size));
 
 }
-bool Rect3::operator!=(const Rect3& p_rval) const {
+bool AABB::operator!=(const AABB& p_rval) const {
 
 	return ((pos!=p_rval.pos) || (size!=p_rval.size));
 
 }
 
-void Rect3::merge_with(const Rect3& p_aabb) {
+void AABB::merge_with(const AABB& p_aabb) {
 
 	Vector3 beg_1,beg_2;
 	Vector3 end_1,end_2;
@@ -289,7 +289,7 @@ void Rect3::merge_with(const Rect3& p_aabb) {
 	size=max-min;
 }
 
-Rect3 Rect3::intersection(const Rect3& p_aabb) const {
+AABB AABB::intersection(const AABB& p_aabb) const {
 
 	Vector3 src_min=pos;
 	Vector3 src_max=pos+size;
@@ -299,7 +299,7 @@ Rect3 Rect3::intersection(const Rect3& p_aabb) const {
 	Vector3 min,max;
 
 	if (src_min.x > dst_max.x || src_max.x < dst_min.x )
-		return Rect3();
+		return AABB();
 	else {
 
 		min.x= ( src_min.x > dst_min.x ) ? src_min.x :dst_min.x;
@@ -308,7 +308,7 @@ Rect3 Rect3::intersection(const Rect3& p_aabb) const {
 	}
 
 	if (src_min.y > dst_max.y || src_max.y < dst_min.y )
-		return Rect3();
+		return AABB();
 	else {
 
 		min.y= ( src_min.y > dst_min.y ) ? src_min.y :dst_min.y;
@@ -317,7 +317,7 @@ Rect3 Rect3::intersection(const Rect3& p_aabb) const {
 	}
 
 	if (src_min.z > dst_max.z || src_max.z < dst_min.z )
-		return Rect3();
+		return AABB();
 	else {
 
 		min.z= ( src_min.z > dst_min.z ) ? src_min.z :dst_min.z;
@@ -326,10 +326,10 @@ Rect3 Rect3::intersection(const Rect3& p_aabb) const {
 	}
 
 
-	return Rect3( min, max-min );
+	return AABB( min, max-min );
 }
 
-bool Rect3::intersects_ray(const Vector3& p_from, const Vector3& p_dir,Vector3* r_clip,Vector3* r_normal) const {
+bool AABB::intersects_ray(const Vector3& p_from, const Vector3& p_dir,Vector3* r_clip,Vector3* r_normal) const {
 
 	Vector3 c1, c2;
 	Vector3 end = pos+size;
@@ -374,7 +374,7 @@ bool Rect3::intersects_ray(const Vector3& p_from, const Vector3& p_dir,Vector3* 
 }
 
 
-bool Rect3::intersects_segment(const Vector3& p_from, const Vector3& p_to,Vector3* r_clip,Vector3* r_normal) const {
+bool AABB::intersects_segment(const Vector3& p_from, const Vector3& p_to,Vector3* r_clip,Vector3* r_normal) const {
 
 	real_t min=0,max=1;
 	int axis=0;
@@ -435,7 +435,7 @@ bool Rect3::intersects_segment(const Vector3& p_from, const Vector3& p_to,Vector
 }
 
 
-bool Rect3::intersects_plane(const Plane &p_plane) const {
+bool AABB::intersects_plane(const Plane &p_plane) const {
 
 	Vector3 points[8] = {
 		Vector3( pos.x	, pos.y		, pos.z		),
@@ -465,7 +465,7 @@ bool Rect3::intersects_plane(const Plane &p_plane) const {
 
 
 
-Vector3 Rect3::get_longest_axis() const {
+Vector3 AABB::get_longest_axis() const {
 
 	Vector3 axis(1,0,0);
 	real_t max_size=size.x;
@@ -482,7 +482,7 @@ Vector3 Rect3::get_longest_axis() const {
 
 	return axis;
 }
-int Rect3::get_longest_axis_index() const {
+int AABB::get_longest_axis_index() const {
 
 	int axis=0;
 	real_t max_size=size.x;
@@ -501,7 +501,7 @@ int Rect3::get_longest_axis_index() const {
 }
 
 
-Vector3 Rect3::get_shortest_axis() const {
+Vector3 AABB::get_shortest_axis() const {
 
 	Vector3 axis(1,0,0);
 	real_t max_size=size.x;
@@ -518,7 +518,7 @@ Vector3 Rect3::get_shortest_axis() const {
 
 	return axis;
 }
-int Rect3::get_shortest_axis_index() const {
+int AABB::get_shortest_axis_index() const {
 
 	int axis=0;
 	real_t max_size=size.x;
@@ -536,26 +536,26 @@ int Rect3::get_shortest_axis_index() const {
 	return axis;
 }
 
-Rect3 Rect3::merge(const Rect3& p_with) const {
+AABB AABB::merge(const AABB& p_with) const {
 
-	Rect3 aabb=*this;
+	AABB aabb=*this;
 	aabb.merge_with(p_with);
 	return aabb;
 }
-Rect3 Rect3::expand(const Vector3& p_vector) const {
-	Rect3 aabb=*this;
+AABB AABB::expand(const Vector3& p_vector) const {
+	AABB aabb=*this;
 	aabb.expand_to(p_vector);
 	return aabb;
 
 }
-Rect3 Rect3::grow(real_t p_by) const {
+AABB AABB::grow(real_t p_by) const {
 
-	Rect3 aabb=*this;
+	AABB aabb=*this;
 	aabb.grow_by(p_by);
 	return aabb;
 }
 
-void Rect3::get_edge(int p_edge,Vector3& r_from,Vector3& r_to) const {
+void AABB::get_edge(int p_edge,Vector3& r_from,Vector3& r_to) const {
 
 	ERR_FAIL_INDEX(p_edge,12);
 	switch(p_edge) {
@@ -631,7 +631,7 @@ void Rect3::get_edge(int p_edge,Vector3& r_from,Vector3& r_to) const {
 
 }
 
-Rect3::operator String() const {
+AABB::operator String() const {
 
 	//return String()+pos +" - "+ size;
 	return String(); // @Todo

--- a/src/core/GodotGlobal.cpp
+++ b/src/core/GodotGlobal.cpp
@@ -17,52 +17,34 @@ void Godot::print_warning(const String& description, const String& function, con
 {
 	int len;
 
-	description.get_c_string(NULL, &len);
-	char * c_desc = (char *)godot::api->godot_alloc(len + 1);
-	description.get_c_string(c_desc, &len);
-	c_desc[len] = '\0';
+	char * c_desc = description.alloc_c_string();
+	char * c_func = function.alloc_c_string();
+	char * c_file = file.alloc_c_string();
 
-	function.get_c_string(NULL, &len);
-	char * c_func = (char *)godot::api->godot_alloc(len + 1);
-	function.get_c_string(c_func, &len);
-	c_func[len] = '\0';
+	if (c_desc != NULL && c_func !=NULL && c_file != NULL) {
+		godot::api->godot_print_warning(c_desc, c_func, c_file, line);
+	};
 
-	file.get_c_string(NULL, &len);
-	char * c_file = (char *)godot::api->godot_alloc(len + 1);
-	file.get_c_string(c_file, &len);
-	c_file[len] = '\0';
-
-	godot::api->godot_print_warning(c_desc, c_func, c_file, line);
-
-	godot::api->godot_free(c_desc);
-	godot::api->godot_free(c_func);
-	godot::api->godot_free(c_file);
+	if (c_desc != NULL) godot::api->godot_free(c_desc);
+	if (c_func != NULL) godot::api->godot_free(c_func);
+	if (c_file != NULL) godot::api->godot_free(c_file);
 }
 
 void Godot::print_error(const String& description, const String& function, const String& file, int line)
 {
 	int len;
 
-	description.get_c_string(NULL, &len);
-	char * c_desc = (char *)godot::api->godot_alloc(len + 1);
-	description.get_c_string(c_desc, &len);
-	c_desc[len] = '\0';
+	char * c_desc = description.alloc_c_string();
+	char * c_func = function.alloc_c_string();
+	char * c_file = file.alloc_c_string();
 
-	function.get_c_string(NULL, &len);
-	char * c_func = (char *)godot::api->godot_alloc(len + 1);
-	function.get_c_string(c_func, &len);
-	c_func[len] = '\0';
+	if (c_desc != NULL && c_func !=NULL && c_file != NULL) {
+		godot::api->godot_print_error(c_desc, c_func, c_file, line);
+	};
 
-	file.get_c_string(NULL, &len);
-	char * c_file = (char *)godot::api->godot_alloc(len + 1);
-	file.get_c_string(c_file, &len);
-	c_file[len] = '\0';
-
-	godot::api->godot_print_error(c_desc, c_func, c_file, line);
-
-	godot::api->godot_free(c_desc);
-	godot::api->godot_free(c_func);
-	godot::api->godot_free(c_file);
+	if (c_desc != NULL) godot::api->godot_free(c_desc);
+	if (c_func != NULL) godot::api->godot_free(c_func);
+	if (c_file != NULL) godot::api->godot_free(c_file);
 }
 
 };

--- a/src/core/GodotGlobal.cpp
+++ b/src/core/GodotGlobal.cpp
@@ -5,7 +5,8 @@
 namespace godot {
 
 void *_RegisterState::nativescript_handle;
-const godot_gdnative_api_struct *api = NULL;
+const godot_gdnative_core_api_struct *api = NULL;
+const godot_gdnative_ext_nativescript_api_struct *nativescript_api = NULL;
 
 void Godot::print(const String& message)
 {
@@ -14,12 +15,54 @@ void Godot::print(const String& message)
 
 void Godot::print_warning(const String& description, const String& function, const String& file, int line)
 {
-	godot::api->godot_print_warning(description.c_string(), function.c_string(), file.c_string(), line);
+	int len;
+
+	description.get_c_string(NULL, &len);
+	char * c_desc = (char *)godot::api->godot_alloc(len + 1);
+	description.get_c_string(c_desc, &len);
+	c_desc[len] = '\0';
+
+	function.get_c_string(NULL, &len);
+	char * c_func = (char *)godot::api->godot_alloc(len + 1);
+	function.get_c_string(c_func, &len);
+	c_func[len] = '\0';
+
+	file.get_c_string(NULL, &len);
+	char * c_file = (char *)godot::api->godot_alloc(len + 1);
+	file.get_c_string(c_file, &len);
+	c_file[len] = '\0';
+
+	godot::api->godot_print_warning(c_desc, c_func, c_file, line);
+
+	godot::api->godot_free(c_desc);
+	godot::api->godot_free(c_func);
+	godot::api->godot_free(c_file);
 }
 
 void Godot::print_error(const String& description, const String& function, const String& file, int line)
 {
-	godot::api->godot_print_error(description.c_string(), function.c_string(), file.c_string(), line);
+	int len;
+
+	description.get_c_string(NULL, &len);
+	char * c_desc = (char *)godot::api->godot_alloc(len + 1);
+	description.get_c_string(c_desc, &len);
+	c_desc[len] = '\0';
+
+	function.get_c_string(NULL, &len);
+	char * c_func = (char *)godot::api->godot_alloc(len + 1);
+	function.get_c_string(c_func, &len);
+	c_func[len] = '\0';
+
+	file.get_c_string(NULL, &len);
+	char * c_file = (char *)godot::api->godot_alloc(len + 1);
+	file.get_c_string(c_file, &len);
+	c_file[len] = '\0';
+
+	godot::api->godot_print_error(c_desc, c_func, c_file, line);
+
+	godot::api->godot_free(c_desc);
+	godot::api->godot_free(c_func);
+	godot::api->godot_free(c_file);
 }
 
 };
@@ -28,6 +71,17 @@ void gdnative_init(godot_gdnative_init_options *options);
 extern "C" void GDN_EXPORT godot_gdnative_init(godot_gdnative_init_options *options)
 {
 	godot::api = options->api_struct;
+
+	// now find our extensions
+	for (int i = 0; i < godot::api->num_extensions; i++) {
+		switch (godot::api->extensions[i]->type) {
+			case GDNATIVE_EXT_NATIVESCRIPT: {
+				godot::nativescript_api = (godot_gdnative_ext_nativescript_api_struct *)godot::api->extensions[i];
+			}; break;
+			default: break;
+		};
+	};
+
 	gdnative_init(options);
 }
 

--- a/src/core/NodePath.cpp
+++ b/src/core/NodePath.cpp
@@ -43,12 +43,6 @@ int NodePath::get_name_count() const
 	return godot::api->godot_node_path_get_name_count(&_node_path);
 }
 
-String NodePath::get_property() const
-{
-	godot_string str = godot::api->godot_node_path_get_property(&_node_path);
-	return *(String *) &str;
-}
-
 String NodePath::get_subname(const int idx) const
 {
 	godot_string str = godot::api->godot_node_path_get_subname(&_node_path, idx);

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -107,6 +107,22 @@ const wchar_t *String::unicode_str() const {
 	return godot::api->godot_string_unicode_str(&_godot_string);
 }
 
+char *String::alloc_c_string() const {
+	int len;
+
+	// figure out the lenght of our string
+	get_c_string(NULL, &len);
+
+	// allocate our buffer
+	char * result = (char *)godot::api->godot_alloc(len + 1);
+	if (result != NULL) {
+		get_c_string(result, &len);
+		result[len] = '\0';
+	}
+	
+	return result;
+}
+
 void String::get_c_string(char *p_dest, int *p_size) const {
 	godot::api->godot_string_get_data(&_godot_string, p_dest, p_size);
 }

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -103,11 +103,19 @@ String::operator NodePath() const {
 	return NodePath(*this);
 }
 
-const char *String::c_string() const {
-	return godot::api->godot_string_c_str(&_godot_string);
+const wchar_t *String::unicode_str() const {
+	return godot::api->godot_string_unicode_str(&_godot_string);
+}
+
+void String::get_c_string(char *p_dest, int *p_size) const {
+	godot::api->godot_string_get_data(&_godot_string, p_dest, p_size);
 }
 
 String operator+(const char *a, const String &b) {
+	return String(a) + b;
+}
+
+String operator+(const wchar_t *a, const String &b) {
 	return String(a) + b;
 }
 

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -3,7 +3,7 @@
 #include "Basis.hpp"
 
 #include "Plane.hpp"
-#include "Rect3.hpp"
+#include "AABB.hpp"
 
 #include "Quat.hpp"
 
@@ -85,14 +85,14 @@ Plane Transform::xform_inv(const Plane& p_plane) const {
 
 }
 
-Rect3 Transform::xform(const Rect3& p_aabb) const {
+AABB Transform::xform(const AABB& p_aabb) const {
 	/* define vertices */
 	Vector3 x=basis.get_axis(0)*p_aabb.size.x;
 	Vector3 y=basis.get_axis(1)*p_aabb.size.y;
 	Vector3 z=basis.get_axis(2)*p_aabb.size.z;
 	Vector3 pos = xform( p_aabb.pos );
 //could be even further optimized
-	Rect3 new_aabb;
+	AABB new_aabb;
 	new_aabb.pos=pos;
 	new_aabb.expand_to( pos+x );
 	new_aabb.expand_to( pos+y );
@@ -104,7 +104,7 @@ Rect3 Transform::xform(const Rect3& p_aabb) const {
 	return new_aabb;
 
 }
-Rect3 Transform::xform_inv(const Rect3& p_aabb) const {
+AABB Transform::xform_inv(const AABB& p_aabb) const {
 
 	/* define vertices */
 	Vector3 vertices[8]={
@@ -119,7 +119,7 @@ Rect3 Transform::xform_inv(const Rect3& p_aabb) const {
 	};
 
 
-	Rect3 ret;
+	AABB ret;
 
 	ret.pos=xform_inv(vertices[0]);
 

--- a/src/core/Variant.cpp
+++ b/src/core/Variant.cpp
@@ -99,9 +99,9 @@ Variant::Variant(const Plane& p_plane)
 }
 
 
-Variant::Variant(const Rect3& p_aabb)
+Variant::Variant(const AABB& p_aabb)
 {
-	godot::api->godot_variant_new_rect3(&_godot_variant, (godot_rect3 *) &p_aabb);
+	godot::api->godot_variant_new_aabb(&_godot_variant, (godot_aabb *) &p_aabb);
 }
 
 Variant::Variant(const Quat& p_quat)
@@ -274,10 +274,10 @@ Variant::operator Plane() const
 	godot_plane s = godot::api->godot_variant_as_plane(&_godot_variant);
 	return *(Plane *) &s;
 }
-Variant::operator Rect3() const
+Variant::operator AABB() const
 {
-	godot_rect3 s = godot::api->godot_variant_as_rect3(&_godot_variant);
-	return *(Rect3 *) &s;
+	godot_aabb s = godot::api->godot_variant_as_aabb(&_godot_variant);
+	return *(AABB *) &s;
 }
 Variant::operator Quat() const
 {


### PR DESCRIPTION
Bunch of fixes so this all compiles again.

There is an issue with a function in tile_map and one in tile_set that gives a Vector2false error. This is an issue in the bindings in Godot that needs to be fixed in Godot itself.
To get around this for now you can manually edit the .hpp files and remove the defaults on the parameters. 