### PR TITLE
Small fixes for build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Edit `SConstruct` file and assign your godot executable path at line:7 `godot_bi
 
 Building cpp_bindings
 ```
-$ scons godotbinpath="../godot_fork/bin/" headers="../godot_headers/" p=linux generate_bindings=yes
+$ scons godotbinpath="../godot_fork/bin/godot_binary" headers="../godot_headers/" p=linux generate_bindings=yes
 ```
 resulting libraries will be placed under `bin/` and the generated headers will be placed under `include/*`
 

--- a/SConstruct
+++ b/SConstruct
@@ -44,7 +44,7 @@ add_sources(sources, "src/core")
 
 if ARGUMENTS.get("generate_bindings", "no") == "yes":
     # TODO Generating the API should be done only if the Godot build is more recent than the JSON file
-    json_api_file = 'godot_api.json'
+    json_api_file = os.path.join(os.getcwd(), 'godot_api.json')
 
     subprocess.call([os.path.expanduser(godot_bin_path), '--gdnative-generate-json-api', json_api_file])
 


### PR DESCRIPTION
Got trouble on mac os x trying to generate bindings from official Godot 3 binary. 

1.  Readme is wrong about godot_bin_path param (related issue https://github.com/GodotNativeTools/godot-cpp/issues/74 ). Fixed it.
2. User on mac os has only read rights inside application directory. So I explicitly generate bindings.json inside build process CWD.