### PR TITLE
Adds variadic template functions for register_signal and emit_signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ public:
 
            /** For registering signal **/
            // register_signal<SimpleClass>("signal_name");
+           // register_signal<SimpleClass>("signal_name", "string_argument", GODOT_VARIANT_TYPE_STRING)
         }
 	
 	String _name;

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -221,7 +221,7 @@ def generate_class_header(used_classes, c):
             if len(method["arguments"]) > 0:
                 method_signature += ", "
                 method_arguments += ", "
-            vararg_templates += "\ttemplate <class... Args> " + method_signature + "Args... args){\n\t\treturn " + method_name + "(" + method_arguments + "godot::helpers::append_all(Array(), args...));\n\t}\n"""
+            vararg_templates += "\ttemplate <class... Args> " + method_signature + "Args... args){\n\t\treturn " + method_name + "(" + method_arguments + "Array::make(args...));\n\t}\n"""
             method_signature += "const Array& __var_args = Array()"
             
         method_signature += ")" + (" const" if method["is_const"] and not c["singleton"] else "")

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -115,6 +115,7 @@ def generate_class_header(used_classes, c):
     
     source.append("")
     
+    vararg_templates = ""
     
     # generate the class definition here
     source.append("class " + class_name + ("" if c["base_class"] == "" else (" : public " + strip_name(c["base_class"])) ) + " {")
@@ -157,14 +158,18 @@ def generate_class_header(used_classes, c):
         
         method_signature += "static " if c["singleton"] else ""
         method_signature += make_gdnative_type(method["return_type"])
-        method_signature += escape_cpp(method["name"]) + "("
+        method_name = escape_cpp(method["name"])
+        method_signature +=  method_name + "("
             
             
         has_default_argument = False
+        method_arguments = ""
         
         for i, argument in enumerate(method["arguments"]):
             method_signature += "const " + make_gdnative_type(argument["type"])
-            method_signature += escape_cpp(argument["name"])
+            argument_name = escape_cpp(argument["name"])
+            method_signature += argument_name
+            method_arguments += argument_name
             
             
             # default arguments
@@ -210,10 +215,13 @@ def generate_class_header(used_classes, c):
             
             if i != len(method["arguments"]) - 1:
                 method_signature += ", "
+                method_arguments += ","
                 
         if method["has_varargs"]:
             if len(method["arguments"]) > 0:
                 method_signature += ", "
+                method_arguments += ", "
+            vararg_templates += "\ttemplate <class... Args> " + method_signature + "Args... args){\n\t\treturn " + method_name + "(" + method_arguments + "godot::helpers::append_all(Array(), args...));\n\t}\n"""
             method_signature += "const Array& __var_args = Array()"
             
         method_signature += ")" + (" const" if method["is_const"] and not c["singleton"] else "")
@@ -221,7 +229,7 @@ def generate_class_header(used_classes, c):
 
         source.append("\t" + method_signature + ";")
     
-    
+    source.append(vararg_templates)
     source.append("};")
     source.append("")
     

--- a/include/core/Array.hpp
+++ b/include/core/Array.hpp
@@ -3,6 +3,7 @@
 
 #include <gdnative/array.h>
 
+#include "Defs.hpp"
 #include "String.hpp"
 
 namespace godot {
@@ -38,6 +39,11 @@ public:
 	Array(const PoolVector3Array& a);
 
 	Array(const PoolColorArray& a);
+
+	template <class... Args>
+	static Array make(Args... args) {
+		return helpers::append_all(Array(), args...);
+	}
 
 	Variant& operator [](const int idx);
 

--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -58,6 +58,42 @@ enum Error {
 	ERR_WTF = ERR_OMFG_THIS_IS_VERY_VERY_BAD ///< short version of the above
 };
 
+	namespace helpers {
+		template <typename T, typename ValueT>
+		T append_all (T appendable, ValueT value) {
+			appendable.append(value);
+			return appendable;
+		}
+
+		template <typename T, typename ValueT, typename... Args>
+		T append_all (T appendable, ValueT value, Args... args) {
+			appendable.append(value);
+			return append_all(appendable, args...);
+		}
+
+		template <typename T>
+		T append_all (T appendable) {
+			return appendable;
+		}
+
+		template <typename KV, typename KeyT, typename ValueT>
+		KV add_all (KV kv, KeyT key, ValueT value) {
+			kv[key] = value;
+			return kv;
+		}
+
+		template <typename KV, typename KeyT, typename ValueT, typename... Args>
+		KV add_all (KV kv, KeyT key, ValueT value, Args... args) {
+			kv[key] = value;
+			return add_all(kv, args...);
+		}
+
+		template <typename KV>
+		KV add_all (KV kv) {
+			return kv;
+		}
+	}
+
 }
 
 #include <stdio.h>

--- a/include/core/Dictionary.hpp
+++ b/include/core/Dictionary.hpp
@@ -16,6 +16,11 @@ public:
 	Dictionary(const Dictionary & other);
 	Dictionary & operator=(const Dictionary & other);
 
+	template <class... Args>
+	static Dictionary make(Args... args) {
+		return helpers::add_all(Dictionary(), args...);
+	}
+
 	void clear();
 
 	bool empty() const;

--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -484,6 +484,11 @@ void register_signal(String name, Dictionary args = Dictionary())
 	}
 }
 
+template<class T, class... Args>
+void register_signal(String name, Args... varargs)
+{
+	register_signal<T>(name, helpers::add_all(Dictionary(), varargs...));
+}
 
 }
 

--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -487,7 +487,7 @@ void register_signal(String name, Dictionary args = Dictionary())
 template<class T, class... Args>
 void register_signal(String name, Args... varargs)
 {
-	register_signal<T>(name, helpers::add_all(Dictionary(), varargs...));
+	register_signal<T>(name, Dictionary::make(varargs...));
 }
 
 }


### PR DESCRIPTION
Implements changes mentioned in #106 

This PR modifies the `register_signal` function to use C++11 variadic templates to streamline the case when signals take arguments. It also adds a new `emit_signal` method to `GodotScript` that is similarly variadic, which proxies to the `Object::emit_signals` function.

Specifically:

- Adds helper template functions to construct a `Dictionary` (really any `foo[key] = value` container, although we expect the container to be ordered for this use case) from a template parameter pack.
- Adds a helper template function to construct an `Array` (really any object with an `append` method) from a template parameter pack.
- Modifies the `register_signal` function to use variadic templates instead of taking a Dictionary explicitly **[WARNING: this will break backwards compatibility!]** Should the old version be kept for now?
- Adds an `emit_signal` variadic template function to `GodotScript` which constructs an `Array` and proxies to `owner->emit_signal`

As mentioned in #106, if a `GodotScript` object is defined where `owner` does not derive from `Object`, then this method must not be called (will result in a compile error, but likely not detected by IDE/autocomplete prior to compilation).

I also saw elsewhere that `GodotScript<T>` may be removed in the future, in which case `emit_signal` would need a new home. Ideally, it would live in `Object`, but since that header is auto-generated, either the generator would need to be aware of this and insert this custom code, or it would have to live someplace else. An icky but simple solution might be to have a freestanding function and use a macro `#define emit_signal(...) owner->emit_signal(__VA_ARGS__)`, but perhaps the version without `GodotScript`/`owner` won't need any of this.

`register_signal` has been tested with:

```cpp
register_signal<Character>("move");
register_signal<Character>("animation_changed", "animation", GODOT_VARIANT_TYPE_STRING);
register_signal<Character>("test", "arg_one", GODOT_VARIANT_TYPE_STRING, "arg_two", GODOT_VARIANT_TYPE_INT);
```

`emit_signal` has been tested with:

```cpp
emit_signal("move");
emit_signal("animation_changed", "run-anim");
emit_signal("test", "hello", 5);
```