### PR TITLE
adds variadic printing function, makes String.format custom placehold…

### DIFF
--- a/include/core/GodotGlobal.hpp
+++ b/include/core/GodotGlobal.hpp
@@ -3,6 +3,7 @@
 
 #include <gdnative_api_struct.gen.h>
 #include "String.hpp"
+#include "Array.hpp"
 
 
 namespace godot {
@@ -20,6 +21,11 @@ public:
 	static void gdnative_init(godot_gdnative_init_options *o);
 	static void gdnative_terminate(godot_gdnative_terminate_options *o);
 	static void nativescript_init(void *handle);
+
+	template <class... Args>
+	static void print(const String& fmt, Args... values) {
+		print(fmt.format(Array::make(values...)));
+	}
 };
 
 

--- a/include/core/String.hpp
+++ b/include/core/String.hpp
@@ -81,6 +81,7 @@ public:
 	int find(String what, int from = 0) const;
 	int find_last(String what) const;
 	int findn(String what, int from = 0) const;
+	String format(Variant values) const;
 	String format(Variant values, String placeholder) const;
 	String get_base_dir() const;
 	String get_basename() const;
@@ -128,6 +129,7 @@ public:
 	String to_upper() const;
 	String xml_escape() const;
 	String xml_unescape() const;
+
 };
 
 String operator+(const char *a, const String &b);

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -267,9 +267,18 @@ int String::findn(String what, int from) const {
 	return godot::api->godot_string_findn(&_godot_string, what._godot_string);
 }
 
-String String::format(Variant values, String placeholder) const {
+String String::format(Variant values) const {
 	String new_string;
 	new_string._godot_string = godot::api->godot_string_format(&_godot_string, (godot_variant *)&values);
+
+	return new_string;
+}
+
+String String::format(Variant values, String placeholder) const {
+	String new_string;
+	godot_char_string contents = godot::api->godot_string_utf8(&placeholder._godot_string);
+	new_string._godot_string = godot::api->godot_string_format_with_custom_placeholder(&_godot_string, (godot_variant *)&values, godot::api->godot_char_string_get_data(&contents));
+	godot::api->godot_char_string_destroy(&contents);
 
 	return new_string;
 }


### PR DESCRIPTION
Another quality of life PR.

Changes are:

- Added a variadic Godot::print overload: `Godot::print(format_string, values...)`
- Removed unused `placeholder` argument from `String::format`
- Added an overload of `String::format` which takes a custom placeholder and implemented it using `godot_string_format_with_custom_placeholder`

The following statements now all print the same thing:
```cpp
Godot::print("Number: {0}, String: {1}, Float: {2}", 1, "a", 1.4f);
Godot::print(String("Number: {0}, String: {1}, Float: {2}").format(Array::make(1, "a", 1.4f)));
Godot::print(String("Number: {number}, String: {string}, Float: {float}").format(Dictionary::make("number", 1, "string", "a", "float", 1.4f)));
Godot::print(String("Number: @0, String: @1, Float: @2").format(Array::make(1, "a", 1.4f), "@_"));
```

@karroffel Is the logic in my format overload for getting the `char*`of the placeholder `String` correct? It works, but I don't know if that's the correct way.