### PR TITLE
change flags for linux release build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -27,13 +27,13 @@ if target_platform == 'linux':
     if ARGUMENTS.get('use_llvm', 'no') == 'yes':
         env['CXX'] = 'clang++'
 
-    env.Append(CCFLAGS = [ '-fPIC', '-g', '-std=c++14', '-Wwrite-strings' ])
+    env.Append(CCFLAGS = [ '-fPIC', '-std=c++14', '-Wwrite-strings' ])
     env.Append(LINKFLAGS = [ '-Wl,-R,\'$$ORIGIN\'' ])
 
     if target == 'debug':
-        env.Append(CCFLAGS = ['-Og'])
+        env.Append(CCFLAGS = ['-Og', '-g'])
     else:
-        env.Append(CCFLAGS = ['-O3'])
+        env.Append(CCFLAGS = ['-O3', '-s'])
 
     if target_arch == '32':
         env.Append(CCFLAGS = [ '-m32' ])


### PR DESCRIPTION
According to Kakoeimon suggested adding -s to the switches on a release build for stripping out debug symbols. brought his gdnative module down from 2.0 Mb to 534 kb.

I can't test on Linux so if someone can verify his findings.... 

Need to add the same changes to the configuration of the gdnative module itself as well.