### PR TITLE
Fix String::split[_floats] crashes, better error macros

### DIFF
--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -107,32 +107,45 @@ typedef float real_t;
 #define _PLANE_EQ_DOT_EPSILON 0.999
 #define _PLANE_EQ_D_EPSILON 0.0001
 
-
-#ifndef ERR_FAIL_COND_V
-#define ERR_FAIL_COND_V(cond, ret) do { if (cond) { return ret; } } while(0)
+// ERR/WARN macros
+#ifndef WARN_PRINT
+#define WARN_PRINT(msg) fprintf(stdout, "ERROR: %s\n", msg); fflush(stdout)
 #endif
 
+#ifndef WARN_PRINTS
+#define WARN_PRINTS(msg) WARN_PRINT(msg.utf8().get_data())
+#endif
+
+#ifndef ERR_PRINT
+#define ERR_PRINT(x) fprintf(stderr, "ERROR: %s\n", x)
+#endif
+
+#ifndef ERR_PRINTS
+#define ERR_PRINTS(msg) ERR_PRINT(msg.utf8().get_data())
+#endif
+
+#ifndef ERR_FAIL
+#define ERR_FAIL() ERR_PRINT("Failed")
+#endif
 
 #ifndef ERR_FAIL_V
-#define ERR_FAIL_V(a) return a
+#define ERR_FAIL_V(a) { ERR_FAIL(); return a; }
+#endif
+
+#ifndef ERR_FAIL_COND
+#define ERR_FAIL_COND(a) do { if (a) { ERR_PRINT(#a); return; } } while(0)
+#endif
+
+#ifndef ERR_FAIL_COND_V
+#define ERR_FAIL_COND_V(cond, ret) do { if (cond) { ERR_PRINT(#cond); return ret; } } while(0)
 #endif
 
 #ifndef ERR_FAIL_INDEX
-#define ERR_FAIL_INDEX(a, b)
-#endif
-
-
-#ifndef ERR_PRINT
-#define ERR_PRINT(msg) fprintf(stderr, "ERROR: %S\n", (msg).unicode_str())
+#define ERR_FAIL_INDEX(a, b) do { if (a < 0 || a >= b) { ERR_FAIL(); return; } } while(0)
 #endif
 
 #ifndef ERR_FAIL_INDEX_V
-#define ERR_FAIL_INDEX_V(a, b, c)
-#endif
-
-
-#ifndef ERR_FAIL_COND
-#define ERR_FAIL_COND(a) do { if (a) { fprintf(stderr, #a); return; } } while(0)
+#define ERR_FAIL_INDEX_V(a, b, c) do { if (a < 0 || a >= b) { ERR_FAIL(); return c; } } while(0)
 #endif
 
 

--- a/include/core/String.hpp
+++ b/include/core/String.hpp
@@ -8,6 +8,7 @@ namespace godot {
 class NodePath;
 class Variant;
 class PoolByteArray;
+class PoolIntArray;
 class PoolRealArray;
 class PoolStringArray;
 class String;
@@ -120,6 +121,7 @@ public:
 	String sha256_text() const;
 	float similarity(String text) const;
 	PoolStringArray split(String divisor, bool allow_empty = true) const;
+	PoolIntArray split_ints(String divisor, bool allow_empty = true) const;
 	PoolRealArray split_floats(String divisor, bool allow_empty = true) const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String substr(int from, int len) const;

--- a/src/core/Color.cpp
+++ b/src/core/Color.cpp
@@ -269,7 +269,7 @@ Color Color::html(const String& p_color)
 	} else if (color.length()==6) {
 		alpha=false;
 	} else {
-		ERR_PRINT(String("Invalid Color Code: ") + p_color);
+		ERR_PRINTS(String("Invalid Color Code: ") + p_color);
 		ERR_FAIL_V(Color());
 	}
 
@@ -277,7 +277,7 @@ Color Color::html(const String& p_color)
 	if (alpha) {
 		a=_parse_col(color,0);
 		if (a<0) {
-			ERR_PRINT("Invalid Color Code: "+p_color);
+			ERR_PRINTS(String("Invalid Color Code: ") + p_color);
 			ERR_FAIL_V(Color());
 		}
 	}
@@ -286,17 +286,17 @@ Color Color::html(const String& p_color)
 
 	int r=_parse_col(color,from+0);
 	if (r<0) {
-		ERR_PRINT("Invalid Color Code: "+p_color);
+		ERR_PRINTS(String("Invalid Color Code: ") + p_color);
 		ERR_FAIL_V(Color());
 	}
 	int g=_parse_col(color,from+2);
 	if (g<0) {
-		ERR_PRINT("Invalid Color Code: "+p_color);
+		ERR_PRINTS(String("Invalid Color Code: ") + p_color);
 		ERR_FAIL_V(Color());
 	}
 	int b=_parse_col(color,from+4);
 	if (b<0) {
-		ERR_PRINT("Invalid Color Code: "+p_color);
+		ERR_PRINTS(String("Invalid Color Code: ") + p_color);
 		ERR_FAIL_V(Color());
 	}
 

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -219,7 +219,7 @@ bool String::begins_with_char_array(const char *p_char_array) const {
 PoolStringArray String::bigrams() const {
 	godot_array arr = godot::api->godot_string_bigrams(&_godot_string);
 
-	return *(PoolStringArray *)&arr;
+	return *(Array *)&arr;
 }
 
 String String::c_escape() const {
@@ -479,13 +479,19 @@ float String::similarity(String text) const {
 PoolStringArray String::split(String divisor, bool allow_empty) const {
 	godot_array arr = godot::api->godot_string_split(&_godot_string, &divisor._godot_string);
 
-	return *(PoolStringArray *)&arr;
+	return *(Array *)&arr;
+}
+
+PoolIntArray String::split_ints(String divisor, bool allow_empty) const {
+	godot_array arr = godot::api->godot_string_split_floats(&_godot_string, &divisor._godot_string);
+
+	return *(Array *)&arr;
 }
 
 PoolRealArray String::split_floats(String divisor, bool allow_empty) const {
 	godot_array arr = godot::api->godot_string_split_floats(&_godot_string, &divisor._godot_string);
 
-	return *(PoolRealArray *)&arr;
+	return *(Array *)&arr;
 }
 
 String String::strip_edges(bool left, bool right) const {


### PR DESCRIPTION
As discussed on IRC this days:

- Fix a bug where calling String::split[_floats] would crash the engine (wrong pointer cast)
- Add String::split_ints function which is missing
- Update the WARN/ERR macros to be more compatible with Godot modules (possibly, in the future, __FUNCTION__, __FILE__, and so on, will be printed too to mimic modules behaviour).

I'll leave the ADD_SIGNAL macro for another PR I still fear it's a bit hacky, and I'll like to do more tests before