### PR TITLE
Change gitignore so we get our gen folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Generated bindings
-src/gen/
-include/gen/
-
 # Misc
 logs/*
 

--- a/include/gen/.gitignore
+++ b/include/gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/gen/.gitignore
+++ b/src/gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Removed gen folder from .gitignore in the root and added .gitignore files in the gen folders. This ensures the gen folders are part of our repository and get created when the repository is cloned but none of the generated files are added to the repository.