### PR TITLE
Preventing crash when function returned null ptr

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -633,7 +633,11 @@ def generate_icall_implementation(icalls):
         
         if ret_type != "void":
             if is_class_type(ret_type):
-                source.append("\treturn (Object *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, ret);")
+                source.append("\tif (ret) {")
+                source.append("\t\treturn (Object *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, ret);")
+                source.append("\t}")
+                source.append("")
+                source.append("\treturn (Object *) ret;")
             else:
                 source.append("\treturn ret;")
         


### PR DESCRIPTION
Ran into this when I was calling ArrayMesh::surface_get_material
This can return a NULL pointer when no material has been assigned to the surface.

When godot_nativescript_get_instance_binding_data is subsequently called to retrieve binding information things go pretty bad because this method assumes a valid pointer.

I've added a some code so check if we have a valid pointer and only call godot_nativescript_get_instance_binding_data if we do, else just return NULL.