### PR TITLE
Profiling support

### DIFF
--- a/include/core/GodotGlobal.hpp
+++ b/include/core/GodotGlobal.hpp
@@ -25,6 +25,8 @@ public:
 	static void nativescript_init(void *handle);
 	static void nativescript_terminate(void *handle);
 
+	static void gdnative_profiling_add_data(const char *p_signature, uint64_t p_time);
+
 	template <class... Args>
 	static void print(const String &fmt, Args... values) {
 		print(fmt.format(Array::make(values...)));

--- a/include/core/GodotProfiling.hpp
+++ b/include/core/GodotProfiling.hpp
@@ -1,0 +1,34 @@
+#ifndef GODOT_PROFILING_HPP
+#define GODOT_PROFILING_HPP
+
+#include "OS.hpp"
+
+
+namespace godot {
+
+class FunctionProfiling {
+	char signature[1024];
+	uint64_t ticks;
+
+public:
+	FunctionProfiling(const char *p_function, const int p_line) {
+		snprintf(signature, 1024, "::%d::%s", p_line, p_function);
+		ticks = OS::get_singleton()->get_ticks_usec();
+	}
+	~FunctionProfiling() {
+		uint64_t t = OS::get_singleton()->get_ticks_usec() - ticks;
+		if (t > 0) {
+			Godot::gdnative_profiling_add_data(signature, t);
+		}
+	}
+};
+
+}
+
+#ifdef DEBUG_ENABLED
+#define GODOT_PROFILING_FUNCTION FunctionProfiling __function_profiling(__FUNCTION__, __LINE__);
+#else
+#define GODOT_PROFILING_FUNCTION
+#endif
+
+#endif

--- a/src/core/GodotGlobal.cpp
+++ b/src/core/GodotGlobal.cpp
@@ -97,6 +97,10 @@ void Godot::gdnative_terminate(godot_gdnative_terminate_options *options) {
 	// reserved for future use.
 }
 
+void Godot::gdnative_profiling_add_data(const char *p_signature, uint64_t p_time) {
+	godot::nativescript_1_1_api->godot_nativescript_profiling_add_data(p_signature, p_time);
+}
+
 void Godot::nativescript_init(void *handle) {
 	godot::_RegisterState::nativescript_handle = handle;
 


### PR DESCRIPTION
This can be added now that https://github.com/godotengine/godot/pull/21229 was merged.

Note: To make functions send profiling data to godot use `GODOT_PROFILING_FUNCTION` (`DEBUG_ENABLED` must be declared on the SConstruct) on each function, like this:

```
void Player::TestFunctions() {
    GODOT_PROFILING_FUNCTION

    // actual code after GODOT_PROFILING_FUNCTION
}
```
