### PR TITLE
Name correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ resulting libraries will be placed under `bin/` and the generated headers will b
 
 > Include `use_llvm=yes` for using clang++
 
-> You may need to specify `headers=../godot_headers` if you have compilation issues related to missing include files
+> You may need to specify `headers_dir=../godot_headers` if you have compilation issues related to missing include files
 
 And our directory structure will be
 ```


### PR DESCRIPTION
SConstruct calls the header path variable "headers_dir", but README.md (as well as the documentation website) calls it "headers".