### PR TITLE
Fix Vector3.distance_to

### DIFF
--- a/src/core/Vector3.cpp
+++ b/src/core/Vector3.cpp
@@ -229,12 +229,12 @@ real_t Vector3::length_squared() const
 
 real_t Vector3::distance_squared_to(const Vector3& b) const
 {
-	return (b-*this).length();
+	return (b-*this).length_squared();
 }
 
 real_t Vector3::distance_to(const Vector3& b) const
 {
-	return (b-*this).length_squared();
+	return (b-*this).length();
 }
 
 real_t Vector3::dot(const Vector3& b) const


### PR DESCRIPTION
`distance_to` was returning `length_squared` and `distance_squared_to` was return `length`. 

Just a simple fix