### PR TITLE
Fix passing NULL pointers as arguments via ptrcall

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -625,7 +625,7 @@ def generate_icall_implementation(icalls):
             if is_primitive(arg) or is_core_type(arg):
                 wrapped_argument += "(void *) &arg" + str(i)
             else:
-                wrapped_argument += "(void *) arg" + str(i) + "->_owner"
+                wrapped_argument += "(void *) (arg" + str(i) + ") ? arg" + str(i) + "->_owner : nullptr"
             
             wrapped_argument += ","
             source.append(wrapped_argument)


### PR DESCRIPTION
For example `Texture::draw` method
```c++
void draw(const RID canvas_item, const Vector2 position, const Color modulate = Color(1,1,1,1), const bool transpose = false, const Ref<Texture> normal_map = nullptr) const;
```
is crashing if no `normal_map` is specified, because of null pointer dereferencing in the generated wrapper
```c++
void ___godot_icall_void_RID_Vector2_Color_bool_Object(godot_method_bind *mb, const Object *inst, const RID& arg0, const Vector2& arg1, const Color& arg2, const bool arg3, const Object *arg4) {
	const void *args[] = {
		(void *) &arg0,
		(void *) &arg1,
		(void *) &arg2,
		(void *) &arg3,
		(void *) arg4->_owner,
	};

	godot::api->godot_method_bind_ptrcall(mb, inst->_owner, args, nullptr);
}
```

This PR adds pointer check, and passes nulls directly to `ptrcall` in this case.
```c++
		(void *) (arg4) ? arg4->_owner : nullptr,
```