### PR TITLE
Fix for issue #224

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -824,7 +824,8 @@ def escape_cpp(name):
         "export":   "_export",
         "template": "_template",
         "new":      "new_",
-        "operator": "_operator"
+        "operator": "_operator",
+        "typename": "_typename"
     }
     if name in escapes:
         return escapes[name]

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -99,7 +99,7 @@ String::~String() {
 }
 
 wchar_t &String::operator[](const int idx) {
-	return *godot::api->godot_string_operator_index(&_godot_string, idx);
+	return *const_cast<wchar_t *>(godot::api->godot_string_operator_index(&_godot_string, idx));
 }
 
 wchar_t String::operator[](const int idx) const {


### PR DESCRIPTION
Added typename to cpp escapes
Remove const from godot_string operator_index return value.

I don't know if the const_cast is ok. Not tested but compiles ok with this.