### PR TITLE
escape 'typename' keyword, which is causing errors when generating bindings

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -824,7 +824,8 @@ def escape_cpp(name):
         "export":   "_export",
         "template": "_template",
         "new":      "new_",
-        "operator": "_operator"
+        "operator": "_operator",
+        "typename": "_typename"
     }
     if name in escapes:
         return escapes[name]


### PR DESCRIPTION
Resolves issue #228. Note: this issue isn't specific to Windows.

The fix added the 'typename' keyword to the escape list, so that things compile fine. Compiled godot-cpp, rebuilt gdnative examples against that and run fine.