### PR TITLE
Set default arch to 64bits for osx platform

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -57,7 +57,7 @@ if env['platform'] == 'windows':
     opts.Update(env)
 
 is64 = False
-if (env['TARGET_ARCH'] == 'amd64' or env['TARGET_ARCH'] == 'emt64' or env['TARGET_ARCH'] == 'x86_64'):
+if (env['platform'] == 'osx' or env['TARGET_ARCH'] == 'amd64' or env['TARGET_ARCH'] == 'emt64' or env['TARGET_ARCH'] == 'x86_64'):
     is64 = True
 if env['bits'] == 'default':
     env['bits'] = '64' if is64 else '32'


### PR DESCRIPTION
`TAGET_ARCH` is set only on windows platforms and the build fails on osx if the `bits` option is not passed explicitly as follow.

```
scons p=osx bits=64 generate_bindings=yes
```

The docs should be updated accordingly or `SConstruct` changed to use 64bits by default on osx.