### PR TITLE
Use Markdown format for the license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2017 GodotNativeTools
 


### PR DESCRIPTION
Follow-up to https://github.com/GodotNativeTools/godot_headers/pull/40.