### PR TITLE
Make Basis look column-major while retaining a row-major representation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -98,7 +98,7 @@ elif env['platform'] == 'windows':
         # MSVC
         env.Append(LINKFLAGS=['/WX'])
         if env['target'] == 'debug':
-            env.Append(CCFLAGS=['/EHsc', '/D_DEBUG', '/MDd'])
+            env.Append(CCFLAGS=['/Z7', '/Od', '/EHsc', '/D_DEBUG', '/MDd'])
         elif env['target'] == 'release':
             env.Append(CCFLAGS=['/O2', '/EHsc', '/DNDEBUG', '/MD'])
     else:

--- a/include/core/Basis.hpp
+++ b/include/core/Basis.hpp
@@ -1,6 +1,8 @@
 #ifndef BASIS_H
 #define BASIS_H
 
+#include <gdnative/basis.h>
+
 #include "Defs.hpp"
 
 #include "Vector3.hpp"
@@ -10,11 +12,290 @@ namespace godot {
 class Quat;
 
 class Basis {
+private:
+	// This helper template is for mimicking the behavior difference between the engine
+	// and script interfaces that logically script sees matrices as column major, while
+	// the engine stores them in row major to efficiently take advantage of SIMD
+	// instructions in case of matrix-vector multiplications.
+	// With this helper template native scripts see the data as if it was column major
+	// without actually transposing the basis matrix at the script-engine boundary.
+	template <int column>
+	class ColumnVector3 {
+	private:
+		template <int column, int component>
+		class ColumnVectorComponent {
+		private:
+			Vector3 elements[3];
+
+		protected:
+			inline ColumnVectorComponent<column, component> &operator=(const ColumnVectorComponent<column, component> &p_value) {
+				return *this = real_t(p_value);
+			}
+			
+			inline ColumnVectorComponent(const ColumnVectorComponent<column, component> &p_value) {
+				*this = real_t(p_value);
+			}
+
+			inline ColumnVectorComponent<column, component> &operator=(const real_t &p_value) {
+				element[component][column] = p_value;
+				return *this;
+			}
+
+			inline operator real_t() const {
+				return element[component][column];
+			}
+		};
+
+	public:
+		enum Axis {
+			AXIS_X,
+			AXIS_Y,
+			AXIS_Z,
+		};
+
+		union {
+			ColumnVectorComponent<column, 0> x;
+			ColumnVectorComponent<column, 1> y;
+			ColumnVectorComponent<column, 2> z;
+
+			Vector3 elements[3]; // Not for direct access, use [] operator instead
+		};
+
+		inline ColumnVector3<column> &operator=(const ColumnVector3<column> &p_value) {
+			return *this = Vector3(p_value);
+		}
+
+		inline ColumnVector3(const ColumnVector3<column> &p_value) {
+			*this = Vector3(p_value);
+		}
+
+		inline ColumnVector3<column> &operator=(const Vector3 &p_value) {
+			elements[0][column] = p_value.x;
+			elements[1][column] = p_value.y;
+			elements[2][column] = p_value.z;
+			return *this;
+		}
+
+		inline operator Vector3() const {
+			return Vector3(elements[0][column], elements[1][column], elements[2][column]);
+		}
+
+		// Unfortunately, we also need to replicate the other interfaces of Vector3 in
+		// order for being able to directly operate on these "meta-Vector3" objects without
+		// an explicit cast or an intermediate assignment to a real Vector3 object.
+
+		inline const real_t &operator[](int p_axis) const {
+			return elements[p_axis][column];
+		}
+
+		inline real_t &operator[](int p_axis) {
+			return elements[p_axis][column];
+		}
+
+		inline ColumnVector3<column> &operator+=(const Vector3 &p_v) {
+			return *this = *this + p_v;
+		}
+
+		inline Vector3 operator+(const Vector3 &p_v) const {
+			return Vector3(*this) + p_v;
+		}
+
+		inline ColumnVector3<column> &operator-=(const Vector3 &p_v) {
+			return *this = *this - p_v;
+		}
+
+		inline Vector3 operator-(const Vector3 &p_v) const {
+			return Vector3(*this) - p_v;
+		}
+
+		inline ColumnVector3<column> &operator*=(const Vector3 &p_v) {
+			return *this = *this * p_v;
+		}
+
+		inline Vector3 operator*(const Vector3 &p_v) const {
+			return Vector3(*this) * p_v;
+		}
+
+		inline ColumnVector3<column> &operator/=(const Vector3 &p_v) {
+			return *this = *this / p_v;
+		}
+
+		inline Vector3 operator/(const Vector3 &p_v) const {
+			return Vector3(*this) / p_v;
+		}
+
+		inline ColumnVector3<column> &operator*=(real_t p_scalar) {
+			return *this = *this * p_scalar;
+		}
+
+		inline Vector3 operator*(real_t p_scalar) const {
+			return Vector3(*this) * p_scalar;
+		}
+
+		inline ColumnVector3<column> &operator/=(real_t p_scalar) {
+			return *this = *this / p_scalar;
+		}
+
+		inline Vector3 operator/(real_t p_scalar) const {
+			return Vector3(*this) / p_scalar;
+		}
+
+		inline Vector3 operator-() const {
+			return -Vector3(*this);
+		}
+
+		inline bool operator==(const Vector3 &p_v) const {
+			return Vector3(*this) == p_v;
+		}
+
+		inline bool operator!=(const Vector3 &p_v) const {
+			return Vector3(*this) != p_v;
+		}
+
+		inline bool operator<(const Vector3 &p_v) const {
+			return Vector3(*this) < p_v;
+		}
+
+		inline bool operator<=(const Vector3 &p_v) const {
+			return Vector3(*this) <= p_v;
+		}
+
+		inline Vector3 abs() const {
+			return Vector3(*this).abs();
+		}
+
+		inline Vector3 ceil() const {
+			return Vector3(*this).ceil();
+		}
+
+		inline Vector3 cross(const Vector3 &b) const {
+			return Vector3(*this).cross(b);
+		}
+
+		inline Vector3 linear_interpolate(const Vector3 &p_b, real_t p_t) const {
+			return Vector3(*this).linear_interpolate(p_b, p_t);
+		}
+
+		inline Vector3 cubic_interpolate(const Vector3 &b, const Vector3 &pre_a, const Vector3 &post_b, const real_t t) const {
+			return Vector3(*this).cubic_interpolate(b, pre_a, post_b, t);
+		}
+
+		inline Vector3 bounce(const Vector3 &p_normal) const {
+			return Vector3(*this).bounce(p_normal);
+		}
+
+		inline real_t length() const {
+			return Vector3(*this).length();
+		}
+
+		inline real_t length_squared() const {
+			return Vector3(*this).length_squared();
+		}
+
+		inline real_t distance_squared_to(const Vector3 &b) const {
+			return Vector3(*this).distance_squared_to(b);
+		}
+
+		inline real_t distance_to(const Vector3 &b) const {
+			return Vector3(*this).distance_to(b);
+		}
+
+		inline real_t dot(const Vector3 &b) const {
+			return Vector3(*this).dot(b);
+		}
+
+		inline real_t angle_to(const Vector3 &b) const {
+			return Vector3(*this).angle_to(b);
+		}
+
+		inline Vector3 floor() const {
+			return Vector3(*this).floor();
+		}
+
+		inline Vector3 inverse() const {
+			return Vector3(*this).inverse();
+		}
+
+		inline bool is_normalized() const {
+			return Vector3(*this).is_normalized();
+		}
+
+		inline Basis outer(const Vector3 &b) const {
+			return Vector3(*this).outer(b);
+		}
+
+		inline int max_axis() const {
+			return Vector3(*this).max_axis();
+		}
+
+		inline int min_axis() const {
+			return Vector3(*this).min_axis();
+		}
+
+		inline void normalize() {
+			Vector3 v = *this;
+			v.normalize();
+			*this = v;
+		}
+
+		inline Vector3 normalized() const {
+			return Vector3(*this).normalized();
+		}
+
+		inline Vector3 reflect(const Vector3 &by) const {
+			return Vector3(*this).reflect(by);
+		}
+
+		inline Vector3 rotated(const Vector3 &axis, const real_t phi) const {
+			return Vector3(*this).rotated(axis, phi);
+		}
+
+		inline void rotate(const Vector3 &p_axis, real_t p_phi) {
+			Vector3 v = *this;
+			v.rotate(p_axis, p_phi);
+			*this = v;
+		}
+
+		inline Vector3 slide(const Vector3 &by) const {
+			return Vector3(*this).slide(by);
+		}
+
+		inline void snap(real_t p_val) {
+			Vector3 v = *this;
+			v.snap(p_val);
+			*this = v;
+		}
+
+		inline Vector3 snapped(const float by) {
+			return Vector3(*this).snapped(by);
+		}
+
+		inline operator String() const {
+			return String(Vector3(*this))
+		}
+	};
+
 public:
 	union {
-		Vector3 elements[3];
-		Vector3 x, y, z;
+		ColumnVector3<0> x;
+		ColumnVector3<1> y;
+		ColumnVector3<2> z;
+
+		Vector3 elements[3]; // Not for direct access, use [] operator instead
 	};
+
+	inline Basis(const Basis &p_basis) {
+		elements[0] = p_basis.elements[0];
+		elements[1] = p_basis.elements[1];
+		elements[2] = p_basis.elements[2];
+	}
+
+	inline Basis &operator=(const Basis &p_basis) {
+		elements[0] = p_basis.elements[0];
+		elements[1] = p_basis.elements[1];
+		elements[2] = p_basis.elements[2];
+		return *this;
+	}
 
 	Basis(const Quat &p_quat); // euler
 	Basis(const Vector3 &p_euler); // euler
@@ -26,8 +307,16 @@ public:
 
 	Basis();
 
-	const Vector3 &operator[](int axis) const;
-	Vector3 &operator[](int axis);
+	const Vector3 &operator[](int axis) const {
+		return get_axis(axis);
+	}
+
+	ColumnVector3<0> &operator[](int axis) {
+		// We need to do a little pointer magic to get this to work, because the
+		// ColumnVector3 template takes the axis as a template parameter.
+		// Don't touch this unless you're sure what you're doing!
+		return (reinterpret_cast<Basis *>(reinterpret_cast<real_t *>(this) + axis))->x;
+	}
 
 	void invert();
 

--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -5,6 +5,8 @@
 
 #include "Defs.hpp"
 
+#include <cmath>
+
 namespace godot {
 
 class String;
@@ -20,36 +22,75 @@ struct Vector2 {
 		real_t height;
 	};
 
+	inline Vector2(real_t p_x, real_t p_y) {
+		x = p_x;
+		y = p_y;
+	}
+
+	inline Vector2() {
+		x = 0;
+		y = 0;
+	}
+
 	inline real_t &operator[](int p_idx) {
 		return p_idx ? y : x;
 	}
+
 	inline const real_t &operator[](int p_idx) const {
 		return p_idx ? y : x;
 	}
 
-	Vector2 operator+(const Vector2 &p_v) const;
+	inline Vector2 operator+(const Vector2 &p_v) const {
+		return Vector2(x + p_v.x, y + p_v.y);
+	}
 
-	void operator+=(const Vector2 &p_v);
+	inline void operator+=(const Vector2 &p_v) {
+		x += p_v.x;
+		y += p_v.y;
+	}
 
-	Vector2 operator-(const Vector2 &p_v) const;
+	inline Vector2 operator-(const Vector2 &p_v) const {
+		return Vector2(x - p_v.x, y - p_v.y);
+	}
 
-	void operator-=(const Vector2 &p_v);
+	inline void operator-=(const Vector2 &p_v) {
+		x -= p_v.x;
+		y -= p_v.y;
+	}
 
-	Vector2 operator*(const Vector2 &p_v1) const;
+	inline Vector2 operator*(const Vector2 &p_v1) const {
+		return Vector2(x * p_v1.x, y * p_v1.y);
+	}
 
-	Vector2 operator*(const real_t &rvalue) const;
+	inline Vector2 operator*(const real_t &rvalue) const {
+		return Vector2(x * rvalue, y * rvalue);
+	}
 
-	void operator*=(const real_t &rvalue);
+	inline void operator*=(const real_t &rvalue) {
+		x *= rvalue;
+		y *= rvalue;
+	}
 
-	inline void operator*=(const Vector2 &rvalue) { *this = *this * rvalue; }
+	inline void operator*=(const Vector2 &rvalue) {
+		*this = *this * rvalue;
+	}
 
-	Vector2 operator/(const Vector2 &p_v1) const;
+	inline Vector2 operator/(const Vector2 &p_v1) const {
+		return Vector2(x / p_v1.x, y / p_v1.y);
+	}
 
-	Vector2 operator/(const real_t &rvalue) const;
+	inline Vector2 operator/(const real_t &rvalue) const {
+		return Vector2(x / rvalue, y / rvalue);
+	}
 
-	void operator/=(const real_t &rvalue);
+	inline void operator/=(const real_t &rvalue) {
+		x /= rvalue;
+		y /= rvalue;
+	}
 
-	Vector2 operator-() const;
+	inline Vector2 operator-() const {
+		return Vector2(-x, -y);
+	}
 
 	bool operator==(const Vector2 &p_vec2) const;
 
@@ -58,23 +99,56 @@ struct Vector2 {
 	inline bool operator<(const Vector2 &p_vec2) const { return (x == p_vec2.x) ? (y < p_vec2.y) : (x < p_vec2.x); }
 	inline bool operator<=(const Vector2 &p_vec2) const { return (x == p_vec2.x) ? (y <= p_vec2.y) : (x <= p_vec2.x); }
 
-	void normalize();
+	inline void normalize() {
+		real_t l = x * x + y * y;
+		if (l != 0) {
+			l = sqrt(l);
+			x /= l;
+			y /= l;
+		}
+	}
 
-	Vector2 normalized() const;
+	inline Vector2 normalized() const {
+		Vector2 v = *this;
+		v.normalize();
+		return v;
+	}
 
-	real_t length() const;
-	real_t length_squared() const;
+	inline real_t length() const {
+		return sqrt(x * x + y * y);
+	}
 
-	real_t distance_to(const Vector2 &p_vector2) const;
-	real_t distance_squared_to(const Vector2 &p_vector2) const;
+	inline real_t length_squared() const {
+		return x * x + y * y;
+	}
 
-	real_t angle_to(const Vector2 &p_vector2) const;
-	real_t angle_to_point(const Vector2 &p_vector2) const;
+	inline real_t distance_to(const Vector2 &p_vector2) const {
+		return sqrt((x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y));
+	}
 
-	real_t dot(const Vector2 &p_other) const;
+	inline real_t distance_squared_to(const Vector2 &p_vector2) const {
+		return (x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y);
+	}
 
-	real_t cross(const Vector2 &p_other) const;
-	Vector2 cross(real_t p_other) const;
+	inline real_t angle_to(const Vector2 &p_vector2) const {
+		return atan2(cross(p_vector2), dot(p_vector2));
+	}
+
+	inline real_t angle_to_point(const Vector2 &p_vector2) const {
+		return atan2(y - p_vector2.y, x - p_vector2.x);
+	}
+
+	inline real_t dot(const Vector2 &p_other) const {
+		return x * p_other.x + y * p_other.y;
+	}
+
+	inline real_t cross(const Vector2 &p_other) const {
+		return x * p_other.y - y * p_other.x;
+	}
+
+	inline Vector2 cross(real_t p_other) const {
+		return Vector2(p_other * y, -p_other * x);
+	}
 
 	Vector2 project(const Vector2 &p_vec) const;
 
@@ -82,39 +156,63 @@ struct Vector2 {
 
 	Vector2 clamped(real_t p_len) const;
 
-	static Vector2 linear_interpolate(const Vector2 &p_a, const Vector2 &p_b, real_t p_t);
+	static inline Vector2 linear_interpolate(const Vector2 &p_a, const Vector2 &p_b, real_t p_t) {
+		Vector2 res = p_a;
+		res.x += (p_t * (p_b.x - p_a.x));
+		res.y += (p_t * (p_b.y - p_a.y));
+		return res;
+	}
 
-	Vector2 linear_interpolate(const Vector2 &p_b, real_t p_t) const;
+	inline Vector2 linear_interpolate(const Vector2 &p_b, real_t p_t) const {
+		Vector2 res = *this;
+		res.x += (p_t * (p_b.x - x));
+		res.y += (p_t * (p_b.y - y));
+		return res;
+	}
+
 	Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_t) const;
 
-	Vector2 slide(const Vector2 &p_vec) const;
+	inline Vector2 slide(const Vector2 &p_vec) const {
+		return p_vec - *this * this->dot(p_vec);
+	}
 
-	Vector2 reflect(const Vector2 &p_vec) const;
+	inline Vector2 reflect(const Vector2 &p_vec) const {
+		return p_vec - *this * this->dot(p_vec) * 2.0;
+	}
 
-	real_t angle() const;
+	inline real_t angle() const {
+		return atan2(y, x);
+	}
 
-	void set_rotation(real_t p_radians);
+	inline void set_rotation(real_t p_radians) {
+		x = cosf(p_radians);
+		y = sinf(p_radians);
+	}
 
-	Vector2 abs() const;
-	Vector2 rotated(real_t p_by) const;
+	inline Vector2 abs() const {
+		return Vector2(fabs(x), fabs(y));
+	}
 
-	Vector2 tangent() const;
+	inline Vector2 rotated(real_t p_by) const {
+		Vector2 v;
+		v.set_rotation(angle() + p_by);
+		v *= length();
+		return v;
+	}
 
-	Vector2 floor() const;
+	inline Vector2 tangent() const {
+		return Vector2(y, -x);
+	}
 
-	Vector2 snapped(const Vector2 &p_by) const;
+	inline Vector2 floor() const {
+		return Vector2(::floor(x), ::floor(y));
+	}
+
+	inline Vector2 snapped(const Vector2 &p_by) const;
+
 	inline real_t aspect() const { return width / height; }
 
 	operator String() const;
-
-	inline Vector2(real_t p_x, real_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
-	inline Vector2() {
-		x = 0;
-		y = 0;
-	}
 };
 
 inline Vector2 operator*(real_t p_scalar, const Vector2 &p_vec) {

--- a/include/core/Vector3.hpp
+++ b/include/core/Vector3.hpp
@@ -1,9 +1,13 @@
 #ifndef VECTOR3_H
 #define VECTOR3_H
 
+#include <gdnative/vector3.h>
+
 #include "Defs.hpp"
 
 #include "String.hpp"
+
+#include <cmath>
 
 namespace godot {
 
@@ -24,80 +28,192 @@ struct Vector3 {
 			real_t z;
 		};
 
-		real_t coord[3];
+		real_t coord[3]; // Not for direct access, use [] operator instead
 	};
 
-	Vector3(real_t x, real_t y, real_t z);
+	inline Vector3(real_t x, real_t y, real_t z) {
+		this->x = x;
+		this->y = y;
+		this->z = z;
+	}
 
-	Vector3();
+	inline Vector3() {
+		this->x = 0;
+		this->y = 0;
+		this->z = 0;
+	}
 
-	const real_t &operator[](int p_axis) const;
+	inline const real_t &operator[](int p_axis) const {
+		return coord[p_axis];
+	}
 
-	real_t &operator[](int p_axis);
+	inline real_t &operator[](int p_axis) {
+		return coord[p_axis];
+	}
 
-	Vector3 &operator+=(const Vector3 &p_v);
+	inline Vector3 &operator+=(const Vector3 &p_v) {
+		x += p_v.x;
+		y += p_v.y;
+		z += p_v.z;
+		return *this;
+	}
 
-	Vector3 operator+(const Vector3 &p_v) const;
+	inline Vector3 operator+(const Vector3 &p_v) const {
+		Vector3 v = *this;
+		v += p_v;
+		return v;
+	}
 
-	Vector3 &operator-=(const Vector3 &p_v);
+	inline Vector3 &operator-=(const Vector3 &p_v) {
+		x -= p_v.x;
+		y -= p_v.y;
+		z -= p_v.z;
+		return *this;
+	}
 
-	Vector3 operator-(const Vector3 &p_v) const;
+	inline Vector3 operator-(const Vector3 &p_v) const {
+		Vector3 v = *this;
+		v -= p_v;
+		return v;
+	}
 
-	Vector3 &operator*=(const Vector3 &p_v);
+	inline Vector3 &operator*=(const Vector3 &p_v) {
+		x *= p_v.x;
+		y *= p_v.y;
+		z *= p_v.z;
+		return *this;
+	}
 
-	Vector3 operator*(const Vector3 &p_v) const;
+	inline Vector3 operator*(const Vector3 &p_v) const {
+		Vector3 v = *this;
+		v *= p_v;
+		return v;
+	}
 
-	Vector3 &operator/=(const Vector3 &p_v);
+	inline Vector3 &operator/=(const Vector3 &p_v) {
+		x /= p_v.x;
+		y /= p_v.y;
+		z /= p_v.z;
+		return *this;
+	}
 
-	Vector3 operator/(const Vector3 &p_v) const;
+	inline Vector3 operator/(const Vector3 &p_v) const {
+		Vector3 v = *this;
+		v /= p_v;
+		return v;
+	}
 
-	Vector3 &operator*=(real_t p_scalar);
+	inline Vector3 &operator*=(real_t p_scalar) {
+		*this *= Vector3(p_scalar, p_scalar, p_scalar);
+		return *this;
+	}
 
-	Vector3 operator*(real_t p_scalar) const;
+	inline Vector3 operator*(real_t p_scalar) const {
+		Vector3 v = *this;
+		v *= p_scalar;
+		return v;
+	}
 
-	Vector3 &operator/=(real_t p_scalar);
+	inline Vector3 &operator/=(real_t p_scalar) {
+		*this /= Vector3(p_scalar, p_scalar, p_scalar);
+		return *this;
+	}
 
-	Vector3 operator/(real_t p_scalar) const;
+	inline Vector3 operator/(real_t p_scalar) const {
+		Vector3 v = *this;
+		v /= p_scalar;
+		return v;
+	}
 
-	Vector3 operator-() const;
+	inline Vector3 operator-() const {
+		return Vector3(-x, -y, -z);
+	}
 
-	bool operator==(const Vector3 &p_v) const;
+	inline bool operator==(const Vector3 &p_v) const {
+		return (x == p_v.x && y == p_v.y && z == p_v.z);
+	}
 
-	bool operator!=(const Vector3 &p_v) const;
+	inline bool operator!=(const Vector3 &p_v) const {
+		return (x != p_v.x || y != p_v.y || z != p_v.z);
+	}
 
 	bool operator<(const Vector3 &p_v) const;
 
 	bool operator<=(const Vector3 &p_v) const;
 
-	Vector3 abs() const;
+	inline Vector3 abs() const {
+		return Vector3(::fabs(x), ::fabs(y), ::fabs(z));
+	}
 
-	Vector3 ceil() const;
+	inline Vector3 ceil() const {
+		return Vector3(::ceil(x), ::ceil(y), ::ceil(z));
+	}
 
-	Vector3 cross(const Vector3 &b) const;
+	inline Vector3 cross(const Vector3 &b) const {
+		Vector3 ret(
+				(y * b.z) - (z * b.y),
+				(z * b.x) - (x * b.z),
+				(x * b.y) - (y * b.x));
 
-	Vector3 linear_interpolate(const Vector3 &p_b, real_t p_t) const;
+		return ret;
+	}
+
+	inline Vector3 linear_interpolate(const Vector3 &p_b, real_t p_t) const {
+		return Vector3(
+				x + (p_t * (p_b.x - x)),
+				y + (p_t * (p_b.y - y)),
+				z + (p_t * (p_b.z - z)));
+	}
 
 	Vector3 cubic_interpolate(const Vector3 &b, const Vector3 &pre_a, const Vector3 &post_b, const real_t t) const;
 
-	Vector3 bounce(const Vector3 &p_normal) const;
+	Vector3 bounce(const Vector3 &p_normal) const {
+		return -reflect(p_normal);
+	}
 
-	real_t length() const;
+	inline real_t length() const {
+		real_t x2 = x * x;
+		real_t y2 = y * y;
+		real_t z2 = z * z;
 
-	real_t length_squared() const;
+		return ::sqrt(x2 + y2 + z2);
+	}
 
-	real_t distance_squared_to(const Vector3 &b) const;
+	inline real_t length_squared() const {
+		real_t x2 = x * x;
+		real_t y2 = y * y;
+		real_t z2 = z * z;
 
-	real_t distance_to(const Vector3 &b) const;
+		return x2 + y2 + z2;
+	}
 
-	real_t dot(const Vector3 &b) const;
+	inline real_t distance_squared_to(const Vector3 &b) const {
+		return (b - *this).length_squared();
+	}
 
-	real_t angle_to(const Vector3 &b) const;
+	inline real_t distance_to(const Vector3 &b) const {
+		return (b - *this).length();
+	}
 
-	Vector3 floor() const;
+	inline real_t dot(const Vector3 &b) const {
+		return x * b.x + y * b.y + z * b.z;
+	}
 
-	Vector3 inverse() const;
+	inline real_t angle_to(const Vector3 &b) const {
+		return std::atan2(cross(b).length(), dot(b));
+	}
 
-	bool is_normalized() const;
+	inline Vector3 floor() const {
+		return Vector3(::floor(x), ::floor(y), ::floor(z));
+	}
+
+	inline Vector3 inverse() const {
+		return Vector3(1.f / x, 1.f / y, 1.f / z);
+	}
+
+	inline bool is_normalized() const {
+		return std::abs(length_squared() - 1.f) < 0.00001f;
+	}
 
 	Basis outer(const Vector3 &b) const;
 
@@ -105,21 +221,46 @@ struct Vector3 {
 
 	int min_axis() const;
 
-	void normalize();
+	inline void normalize() {
+		real_t l = length();
+		if (l == 0) {
+			x = y = z = 0;
+		} else {
+			x /= l;
+			y /= l;
+			z /= l;
+		}
+	}
 
-	Vector3 normalized() const;
+	inline Vector3 normalized() const {
+		Vector3 v = *this;
+		v.normalize();
+		return v;
+	}
 
-	Vector3 reflect(const Vector3 &by) const;
+	inline Vector3 reflect(const Vector3 &by) const {
+		return by - *this * this->dot(by) * 2.f;
+	}
 
-	Vector3 rotated(const Vector3 &axis, const real_t phi) const;
+	inline Vector3 rotated(const Vector3 &axis, const real_t phi) const {
+		Vector3 v = *this;
+		v.rotate(axis, phi);
+		return v;
+	}
 
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 
-	Vector3 slide(const Vector3 &by) const;
+	inline Vector3 slide(const Vector3 &by) const {
+		return by - *this * this->dot(by);
+	}
 
 	void snap(real_t p_val);
 
-	Vector3 snapped(const float by);
+	inline Vector3 snapped(const float by) {
+		Vector3 v = *this;
+		v.snap(by);
+		return v;
+	}
 
 	operator String() const;
 };

--- a/src/core/Basis.cpp
+++ b/src/core/Basis.cpp
@@ -31,15 +31,6 @@ Basis::Basis() {
 	elements[2][2] = 1;
 }
 
-const Vector3 &Basis::operator[](int axis) const {
-
-	return elements[axis];
-}
-Vector3 &Basis::operator[](int axis) {
-
-	return elements[axis];
-}
-
 #define cofac(row1, col1, row2, col2) \
 	(elements[row1][col1] * elements[row2][col2] - elements[row1][col2] * elements[row2][col1])
 

--- a/src/core/Vector2.cpp
+++ b/src/core/Vector2.cpp
@@ -1,60 +1,10 @@
 #include "Vector2.hpp"
 
-#include <cmath>
-
 #include <gdnative/vector2.h>
 
 #include "String.hpp"
 
 namespace godot {
-
-Vector2 Vector2::operator+(const Vector2 &p_v) const {
-	return Vector2(x + p_v.x, y + p_v.y);
-}
-
-void Vector2::operator+=(const Vector2 &p_v) {
-	x += p_v.x;
-	y += p_v.y;
-}
-
-Vector2 Vector2::operator-(const Vector2 &p_v) const {
-	return Vector2(x - p_v.x, y - p_v.y);
-}
-
-void Vector2::operator-=(const Vector2 &p_v) {
-	x -= p_v.x;
-	y -= p_v.y;
-}
-
-Vector2 Vector2::operator*(const Vector2 &p_v1) const {
-	return Vector2(x * p_v1.x, y * p_v1.y);
-}
-
-Vector2 Vector2::operator*(const real_t &rvalue) const {
-	return Vector2(x * rvalue, y * rvalue);
-}
-
-void Vector2::operator*=(const real_t &rvalue) {
-	x *= rvalue;
-	y *= rvalue;
-}
-
-Vector2 Vector2::operator/(const Vector2 &p_v1) const {
-	return Vector2(x / p_v1.x, y / p_v1.y);
-}
-
-Vector2 Vector2::operator/(const real_t &rvalue) const {
-	return Vector2(x / rvalue, y / rvalue);
-}
-
-void Vector2::operator/=(const real_t &rvalue) {
-	x /= rvalue;
-	y /= rvalue;
-}
-
-Vector2 Vector2::operator-() const {
-	return Vector2(-x, -y);
-}
 
 bool Vector2::operator==(const Vector2 &p_vec2) const {
 	return x == p_vec2.x && y == p_vec2.y;
@@ -62,56 +12,6 @@ bool Vector2::operator==(const Vector2 &p_vec2) const {
 
 bool Vector2::operator!=(const Vector2 &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
-}
-
-void Vector2::normalize() {
-	real_t l = x * x + y * y;
-	if (l != 0) {
-		l = sqrt(l);
-		x /= l;
-		y /= l;
-	}
-}
-
-Vector2 Vector2::normalized() const {
-	Vector2 v = *this;
-	v.normalize();
-	return v;
-}
-
-real_t Vector2::length() const {
-	return sqrt(x * x + y * y);
-}
-real_t Vector2::length_squared() const {
-	return x * x + y * y;
-}
-
-real_t Vector2::distance_to(const Vector2 &p_vector2) const {
-	return sqrt((x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y));
-}
-
-real_t Vector2::distance_squared_to(const Vector2 &p_vector2) const {
-	return (x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y);
-}
-
-real_t Vector2::angle_to(const Vector2 &p_vector2) const {
-	return atan2(cross(p_vector2), dot(p_vector2));
-}
-
-real_t Vector2::angle_to_point(const Vector2 &p_vector2) const {
-	return atan2(y - p_vector2.y, x - p_vector2.x);
-}
-
-real_t Vector2::dot(const Vector2 &p_other) const {
-	return x * p_other.x + y * p_other.y;
-}
-
-real_t Vector2::cross(const Vector2 &p_other) const {
-	return x * p_other.y - y * p_other.x;
-}
-
-Vector2 Vector2::cross(real_t p_other) const {
-	return Vector2(p_other * y, -p_other * x);
 }
 
 Vector2 Vector2::project(const Vector2 &p_vec) const {
@@ -134,19 +34,6 @@ Vector2 Vector2::clamped(real_t p_len) const {
 	return v;
 }
 
-Vector2 Vector2::linear_interpolate(const Vector2 &p_a, const Vector2 &p_b, real_t p_t) {
-	Vector2 res = p_a;
-	res.x += (p_t * (p_b.x - p_a.x));
-	res.y += (p_t * (p_b.y - p_a.y));
-	return res;
-}
-
-Vector2 Vector2::linear_interpolate(const Vector2 &p_b, real_t p_t) const {
-	Vector2 res = *this;
-	res.x += (p_t * (p_b.x - x));
-	res.y += (p_t * (p_b.y - y));
-	return res;
-}
 Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_t) const {
 	Vector2 p0 = p_pre_a;
 	Vector2 p1 = *this;
@@ -165,45 +52,6 @@ Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, c
 		  0.5;
 
 	return out;
-}
-
-Vector2 Vector2::slide(const Vector2 &p_vec) const {
-	return p_vec - *this * this->dot(p_vec);
-}
-
-Vector2 Vector2::reflect(const Vector2 &p_vec) const {
-	return p_vec - *this * this->dot(p_vec) * 2.0;
-}
-
-real_t Vector2::angle() const {
-	return atan2(y, x);
-}
-
-void Vector2::set_rotation(real_t p_radians) {
-
-	x = cosf(p_radians);
-	y = sinf(p_radians);
-}
-
-Vector2 Vector2::abs() const {
-
-	return Vector2(fabs(x), fabs(y));
-}
-
-Vector2 Vector2::rotated(real_t p_by) const {
-	Vector2 v;
-	v.set_rotation(angle() + p_by);
-	v *= length();
-	return v;
-}
-
-Vector2 Vector2::tangent() const {
-
-	return Vector2(y, -x);
-}
-
-Vector2 Vector2::floor() const {
-	return Vector2(::floor(x), ::floor(y));
 }
 
 Vector2 Vector2::snapped(const Vector2 &p_by) const {

--- a/src/core/Vector3.cpp
+++ b/src/core/Vector3.cpp
@@ -4,117 +4,9 @@
 
 #include <stdlib.h>
 
-#include <cmath>
-
 #include "Basis.hpp"
 
 namespace godot {
-
-Vector3::Vector3(real_t x, real_t y, real_t z) {
-	this->x = x;
-	this->y = y;
-	this->z = z;
-}
-
-Vector3::Vector3() {
-	this->x = 0;
-	this->y = 0;
-	this->z = 0;
-}
-
-const real_t &Vector3::operator[](int p_axis) const {
-	return coord[p_axis];
-}
-
-real_t &Vector3::operator[](int p_axis) {
-	return coord[p_axis];
-}
-
-Vector3 &Vector3::operator+=(const Vector3 &p_v) {
-	x += p_v.x;
-	y += p_v.y;
-	z += p_v.z;
-	return *this;
-}
-
-Vector3 Vector3::operator+(const Vector3 &p_v) const {
-	Vector3 v = *this;
-	v += p_v;
-	return v;
-}
-
-Vector3 &Vector3::operator-=(const Vector3 &p_v) {
-	x -= p_v.x;
-	y -= p_v.y;
-	z -= p_v.z;
-	return *this;
-}
-
-Vector3 Vector3::operator-(const Vector3 &p_v) const {
-	Vector3 v = *this;
-	v -= p_v;
-	return v;
-}
-
-Vector3 &Vector3::operator*=(const Vector3 &p_v) {
-	x *= p_v.x;
-	y *= p_v.y;
-	z *= p_v.z;
-	return *this;
-}
-
-Vector3 Vector3::operator*(const Vector3 &p_v) const {
-	Vector3 v = *this;
-	v *= p_v;
-	return v;
-}
-
-Vector3 &Vector3::operator/=(const Vector3 &p_v) {
-	x /= p_v.x;
-	y /= p_v.y;
-	z /= p_v.z;
-	return *this;
-}
-
-Vector3 Vector3::operator/(const Vector3 &p_v) const {
-	Vector3 v = *this;
-	v /= p_v;
-	return v;
-}
-
-Vector3 &Vector3::operator*=(real_t p_scalar) {
-	*this *= Vector3(p_scalar, p_scalar, p_scalar);
-	return *this;
-}
-
-Vector3 Vector3::operator*(real_t p_scalar) const {
-	Vector3 v = *this;
-	v *= p_scalar;
-	return v;
-}
-
-Vector3 &Vector3::operator/=(real_t p_scalar) {
-	*this /= Vector3(p_scalar, p_scalar, p_scalar);
-	return *this;
-}
-
-Vector3 Vector3::operator/(real_t p_scalar) const {
-	Vector3 v = *this;
-	v /= p_scalar;
-	return v;
-}
-
-Vector3 Vector3::operator-() const {
-	return Vector3(-x, -y, -z);
-}
-
-bool Vector3::operator==(const Vector3 &p_v) const {
-	return (x == p_v.x && y == p_v.y && z == p_v.z);
-}
-
-bool Vector3::operator!=(const Vector3 &p_v) const {
-	return (x != p_v.x || y != p_v.y || z != p_v.z);
-}
 
 bool Vector3::operator<(const Vector3 &p_v) const {
 	if (x == p_v.x) {
@@ -138,30 +30,6 @@ bool Vector3::operator<=(const Vector3 &p_v) const {
 	}
 }
 
-Vector3 Vector3::abs() const {
-	return Vector3(::fabs(x), ::fabs(y), ::fabs(z));
-}
-
-Vector3 Vector3::ceil() const {
-	return Vector3(::ceil(x), ::ceil(y), ::ceil(z));
-}
-
-Vector3 Vector3::cross(const Vector3 &b) const {
-	Vector3 ret(
-			(y * b.z) - (z * b.y),
-			(z * b.x) - (x * b.z),
-			(x * b.y) - (y * b.x));
-
-	return ret;
-}
-
-Vector3 Vector3::linear_interpolate(const Vector3 &p_b, real_t p_t) const {
-	return Vector3(
-			x + (p_t * (p_b.x - x)),
-			y + (p_t * (p_b.y - y)),
-			z + (p_t * (p_b.z - z)));
-}
-
 Vector3 Vector3::cubic_interpolate(const Vector3 &b, const Vector3 &pre_a, const Vector3 &post_b, const real_t t) const {
 	Vector3 p0 = pre_a;
 	Vector3 p1 = *this;
@@ -180,54 +48,6 @@ Vector3 Vector3::cubic_interpolate(const Vector3 &b, const Vector3 &pre_a, const
 	return out;
 }
 
-Vector3 Vector3::bounce(const Vector3 &p_normal) const {
-	return -reflect(p_normal);
-}
-
-real_t Vector3::length() const {
-	real_t x2 = x * x;
-	real_t y2 = y * y;
-	real_t z2 = z * z;
-
-	return ::sqrt(x2 + y2 + z2);
-}
-
-real_t Vector3::length_squared() const {
-	real_t x2 = x * x;
-	real_t y2 = y * y;
-	real_t z2 = z * z;
-
-	return x2 + y2 + z2;
-}
-
-real_t Vector3::distance_squared_to(const Vector3 &b) const {
-	return (b - *this).length_squared();
-}
-
-real_t Vector3::distance_to(const Vector3 &b) const {
-	return (b - *this).length();
-}
-
-real_t Vector3::dot(const Vector3 &b) const {
-	return x * b.x + y * b.y + z * b.z;
-}
-
-real_t Vector3::angle_to(const Vector3 &b) const {
-	return std::atan2(cross(b).length(), dot(b));
-}
-
-Vector3 Vector3::floor() const {
-	return Vector3(::floor(x), ::floor(y), ::floor(z));
-}
-
-Vector3 Vector3::inverse() const {
-	return Vector3(1.0 / x, 1.0 / y, 1.0 / z);
-}
-
-bool Vector3::is_normalized() const {
-	return std::abs(length_squared() - 1.0) < 0.00001;
-}
-
 Basis Vector3::outer(const Vector3 &b) const {
 	Vector3 row0(x * b.x, x * b.y, x * b.z);
 	Vector3 row1(y * b.x, y * b.y, y * b.z);
@@ -243,39 +63,8 @@ int Vector3::min_axis() const {
 	return x < y ? (x < z ? 0 : 2) : (y < z ? 1 : 2);
 }
 
-void Vector3::normalize() {
-	real_t l = length();
-	if (l == 0) {
-		x = y = z = 0;
-	} else {
-		x /= l;
-		y /= l;
-		z /= l;
-	}
-}
-
-Vector3 Vector3::normalized() const {
-	Vector3 v = *this;
-	v.normalize();
-	return v;
-}
-
-Vector3 Vector3::reflect(const Vector3 &by) const {
-	return by - *this * this->dot(by) * 2.0;
-}
-
-Vector3 Vector3::rotated(const Vector3 &axis, const real_t phi) const {
-	Vector3 v = *this;
-	v.rotate(axis, phi);
-	return v;
-}
-
 void Vector3::rotate(const Vector3 &p_axis, real_t p_phi) {
 	*this = Basis(p_axis, p_phi).xform(*this);
-}
-
-Vector3 Vector3::slide(const Vector3 &by) const {
-	return by - *this * this->dot(by);
 }
 
 // this is ugly as well, but hey, I'm a simple man
@@ -288,12 +77,6 @@ void Vector3::snap(real_t p_val) {
 }
 
 #undef _ugly_stepify
-
-Vector3 Vector3::snapped(const float by) {
-	Vector3 v = *this;
-	v.snap(by);
-	return v;
-}
 
 Vector3::operator String() const {
 	return String::num(x) + ", " + String::num(y) + ", " + String::num(z);


### PR DESCRIPTION
Per https://github.com/godotengine/godot/issues/14553:
Godot stores Basis in row-major layout for more change for efficiently
taking advantage of SIMD instructions, but in scripts Basis looks like and
is accessible in a column-major format.

This change modifies the C++ binding so that from the script's perspective
Basis does look like if it was column-major while retaining a row-major
in-memory representation. This is achieved using a set of helper template
classes which allow accessing individual columns whose components are
non-continues in memory as if it was a Vector3 type. This ensures script
interface compatibility without needing to transpose the Basis every time
it is passed over the script-engine boundary.

Also made most of the Vecto2 and Vector3 class interfaces inlined in the
process for increased performance.

While unrelated (but didn't want to file a separate PR for it), this change
adds the necessary flags to have debug symbol information under MSVC.

Fixes #241.