### PR TITLE
Fix bug in Basis [] operator and add missing Transform-Vector3 * operator

### DIFF
--- a/include/core/Basis.hpp
+++ b/include/core/Basis.hpp
@@ -307,7 +307,7 @@ public:
 
 	Basis();
 
-	const Vector3 &operator[](int axis) const {
+	const Vector3 operator[](int axis) const {
 		return get_axis(axis);
 	}
 

--- a/include/core/Transform.hpp
+++ b/include/core/Transform.hpp
@@ -58,6 +58,13 @@ public:
 	void operator*=(const Transform &p_transform);
 	Transform operator*(const Transform &p_transform) const;
 
+	inline Vector3 operator*(const Vector3 &p_vector) const {
+		return Vector3(
+				basis.elements[0].dot(p_vector) + origin.x,
+				basis.elements[1].dot(p_vector) + origin.y,
+				basis.elements[2].dot(p_vector) + origin.z);
+	}
+
 	Transform interpolate_with(const Transform &p_transform, real_t p_c) const;
 
 	Transform inverse_xform(const Transform &t) const;

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -35,9 +35,9 @@ void Transform::set(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_
 Vector3 Transform::xform(const Vector3 &p_vector) const {
 
 	return Vector3(
-			basis[0].dot(p_vector) + origin.x,
-			basis[1].dot(p_vector) + origin.y,
-			basis[2].dot(p_vector) + origin.z);
+			basis.elements[0].dot(p_vector) + origin.x,
+			basis.elements[1].dot(p_vector) + origin.y,
+			basis.elements[2].dot(p_vector) + origin.z);
 }
 Vector3 Transform::xform_inv(const Vector3 &p_vector) const {
 
@@ -241,7 +241,7 @@ void Transform::translate(real_t p_tx, real_t p_ty, real_t p_tz) {
 void Transform::translate(const Vector3 &p_translation) {
 
 	for (int i = 0; i < 3; i++) {
-		origin[i] += basis[i].dot(p_translation);
+		origin[i] += basis.elements[i].dot(p_translation);
 	}
 }
 


### PR DESCRIPTION
The [] operator of Basis was returning a reference to a temporary, so fixed it.
There was no * operator in Transform equivalent to the xform function, which is
not in line with GDScript behavior.

Also fixed remaining cases where Transform relied on the old behavior of the
[] operator of Basis (i.e. that it returns the row, not the column).