### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,76 @@
+language: cpp
+dist: xenial
+osx_image: xcode10.1
+
+env:
+  global:
+    - SCONS_CACHE="$HOME/.scons_cache"
+    - SCONS_CACHE_LIMIT=1024
+
+cache:
+  directories:
+    - $SCONS_CACHE
+
+matrix:
+  include:
+    - name: Linux Debug + Static Checks
+      os: linux
+      compiler: gcc
+      env: TARGET=debug STATIC_CHECKS=yes
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-6.0
+          packages:
+            [scons, pkg-config, build-essential, p7zip-full, clang-format-6.0]
+
+    - name: Linux Release
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            [scons, pkg-config, build-essential, p7zip-full]
+      env: TARGET=release
+
+    - name: macOS Debug
+      os: osx
+      compiler: clang
+      env: TARGET=debug
+
+    - name: macOS Release
+      os: osx
+      compiler: clang
+      env: TARGET=release
+
+    - name: Windows MSVC Debug
+      os: windows
+      env: TARGET=debug
+
+    - name: Windows MSVC Release
+      os: windows
+      env: TARGET=release
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update;
+      brew install scons p7zip;
+    fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      curl -LO https://downloads.sourceforge.net/project/scons/scons-local/3.0.5/scons-local-3.0.5.zip;
+      unzip scons-local-3.0.5.zip;
+    fi
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      export SCONS="./scons.bat";
+    else
+      export SCONS="scons";
+    fi
+
+  - $SCONS target="$TARGET" bits=64 generate_bindings=yes $SCONS_FLAGS;
+
+  - if [[ "$STATIC_CHECKS" == "yes" ]]; then
+      sh ./misc/travis/clang-format.sh;
+    fi

--- a/misc/travis/clang-format.sh
+++ b/misc/travis/clang-format.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+CLANG_FORMAT=clang-format-6.0
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    # Check the whole commit range against $TRAVIS_BRANCH, the base merge branch
+    # We could use $TRAVIS_COMMIT_RANGE but it doesn't play well with force pushes
+    RANGE="$(git rev-parse $TRAVIS_BRANCH) HEAD"
+else
+    # Test only the last commit
+    RANGE=HEAD
+fi
+
+FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -v thirdparty/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc|java|glsl)$")
+echo "Checking files:\n$FILES"
+
+# create a random filename to store our generated patch
+prefix="static-check-clang-format"
+suffix="$(date +%s)"
+patch="/tmp/$prefix-$suffix.patch"
+
+for file in $FILES; do
+    "$CLANG_FORMAT" -style=file "$file" | \
+        diff -u "$file" - | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if [ ! -s "$patch" ] ; then
+    printf "Files in this commit comply with the clang-format rules.\n"
+    rm -f "$patch"
+    exit 0
+fi
+
+# a patch has been created, notify the user and exit
+printf "\n*** The following differences were found between the code to commit "
+printf "and the clang-format rules:\n\n"
+cat "$patch"
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1


### PR DESCRIPTION
This ensures the repository is always in a buildable state, while also checking for code style violations.

`clang-format.sh` was taken from https://github.com/godotengine/godot/blob/c50ab02e4ceb1517f3a87a7bac82967ba1e6e2a9/misc/travis/clang-format.sh.