### PR TITLE
Error message improvements

### DIFF
--- a/include/core/Array.hpp
+++ b/include/core/Array.hpp
@@ -3,10 +3,45 @@
 
 #include <gdnative/array.h>
 
-#include "Defs.hpp"
 #include "String.hpp"
 
 namespace godot {
+
+namespace helpers {
+template <typename T, typename ValueT>
+T append_all(T appendable, ValueT value) {
+	appendable.append(value);
+	return appendable;
+}
+
+template <typename T, typename ValueT, typename... Args>
+T append_all(T appendable, ValueT value, Args... args) {
+	appendable.append(value);
+	return append_all(appendable, args...);
+}
+
+template <typename T>
+T append_all(T appendable) {
+	return appendable;
+}
+
+template <typename KV, typename KeyT, typename ValueT>
+KV add_all(KV kv, KeyT key, ValueT value) {
+	kv[key] = value;
+	return kv;
+}
+
+template <typename KV, typename KeyT, typename ValueT, typename... Args>
+KV add_all(KV kv, KeyT key, ValueT value, Args... args) {
+	kv[key] = value;
+	return add_all(kv, args...);
+}
+
+template <typename KV>
+KV add_all(KV kv) {
+	return kv;
+}
+} // namespace helpers
 
 class Variant;
 class PoolByteArray;


### PR DESCRIPTION
Changed error message macros to actually use Godot's error reporting
facilities instead of outputting straight to stderr. This enables
GDNative errors to actually show up inside the editor.

Messages and set of available macros now also better matches that of
the engine itself.