### PR TITLE
Add MSYS/MinGW compiling support on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ if sys.platform.startswith('linux'):
     host_platform = 'linux'
 elif sys.platform == 'darwin':
     host_platform = 'osx'
-elif sys.platform == 'win32':
+elif sys.platform == 'win32' or sys.platform == 'msys':
     host_platform = 'windows'
 else:
     raise ValueError(


### PR DESCRIPTION
As noticed there: https://github.com/GodotNativeTools/godot-cpp/pull/261

Tested successfully with [MSYS2](https://www.msys2.org/) (`pacman -S mingw-w64-x86_64-gcc python2 scons`) with the following command:
```
scons platform=windows generate_bindings=yes use_mingw=1 bits=64
```

