### PR TITLE
Store all main entry points to the currently available APIs

### DIFF
--- a/include/core/GodotGlobal.hpp
+++ b/include/core/GodotGlobal.hpp
@@ -9,8 +9,16 @@ namespace godot {
 
 extern "C" const godot_gdnative_core_api_struct *api;
 extern "C" const godot_gdnative_core_1_1_api_struct *core_1_1_api;
+extern "C" const godot_gdnative_core_1_2_api_struct *core_1_2_api;
+
 extern "C" const godot_gdnative_ext_nativescript_api_struct *nativescript_api;
 extern "C" const godot_gdnative_ext_nativescript_1_1_api_struct *nativescript_1_1_api;
+extern "C" const godot_gdnative_ext_pluginscript_api_struct *pluginscript_api;
+extern "C" const godot_gdnative_ext_android_api_struct *android_api;
+extern "C" const godot_gdnative_ext_arvr_api_struct *arvr_api;
+extern "C" const godot_gdnative_ext_videodecoder_api_struct *videodecoder_api;
+extern "C" const godot_gdnative_ext_net_api_struct *net_api;
+extern "C" const godot_gdnative_ext_net_3_2_api_struct *net_3_2_api;
 
 extern "C" const void *gdnlib;
 

--- a/src/core/GodotGlobal.cpp
+++ b/src/core/GodotGlobal.cpp
@@ -27,9 +27,16 @@ int _RegisterState::language_index;
 
 const godot_gdnative_core_api_struct *api = nullptr;
 const godot_gdnative_core_1_1_api_struct *core_1_1_api = nullptr;
+const godot_gdnative_core_1_2_api_struct *core_1_2_api = nullptr;
 
 const godot_gdnative_ext_nativescript_api_struct *nativescript_api = nullptr;
 const godot_gdnative_ext_nativescript_1_1_api_struct *nativescript_1_1_api = nullptr;
+const godot_gdnative_ext_pluginscript_api_struct *pluginscript_api = nullptr;
+const godot_gdnative_ext_android_api_struct *android_api = nullptr;
+const godot_gdnative_ext_arvr_api_struct *arvr_api = nullptr;
+const godot_gdnative_ext_videodecoder_api_struct *videodecoder_api = nullptr;
+const godot_gdnative_ext_net_api_struct *net_api = nullptr;
+const godot_gdnative_ext_net_3_2_api_struct *net_3_2_api = nullptr;
 
 const void *gdnlib = NULL;
 
@@ -81,6 +88,8 @@ void Godot::gdnative_init(godot_gdnative_init_options *options) {
 	while (core_extension) {
 		if (core_extension->version.major == 1 && core_extension->version.minor == 1) {
 			godot::core_1_1_api = (const godot_gdnative_core_1_1_api_struct *)core_extension;
+		} else if (core_extension->version.major == 1 && core_extension->version.minor == 2) {
+			godot::core_1_2_api = (const godot_gdnative_core_1_2_api_struct *)core_extension;
 		}
 		core_extension = core_extension->next;
 	}
@@ -101,6 +110,32 @@ void Godot::gdnative_init(godot_gdnative_init_options *options) {
 					extension = extension->next;
 				}
 			} break;
+			case GDNATIVE_EXT_PLUGINSCRIPT: {
+				godot::pluginscript_api = (const godot_gdnative_ext_pluginscript_api_struct *)godot::api->extensions[i];
+			} break;
+			case GDNATIVE_EXT_ANDROID: {
+				godot::android_api = (const godot_gdnative_ext_android_api_struct *)godot::api->extensions[i];
+			} break;
+			case GDNATIVE_EXT_ARVR: {
+				godot::arvr_api = (const godot_gdnative_ext_arvr_api_struct *)godot::api->extensions[i];
+			} break;
+			case GDNATIVE_EXT_VIDEODECODER: {
+				godot::videodecoder_api = (const godot_gdnative_ext_videodecoder_api_struct *)godot::api->extensions[i];
+			} break;
+			case GDNATIVE_EXT_NET: {
+				godot::net_api = (const godot_gdnative_ext_net_api_struct *)godot::api->extensions[i];
+
+				const godot_gdnative_api_struct *extension = godot::net_api->next;
+
+				while (extension) {
+					if (extension->version.major == 3 && extension->version.minor == 2) {
+						godot::net_3_2_api = (const godot_gdnative_ext_net_3_2_api_struct *)extension;
+					}
+
+					extension = extension->next;
+				}
+			} break;
+
 			default: break;
 		}
 	}


### PR DESCRIPTION
We were only capturing the core struct pointer and nativescript struct pointers.
Added all the others we currently support. 