### PR TITLE
Godot-cpp compile for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ $ scons platform=<your platform> generate_bindings=yes
 $ cd ..
 ```
 For android:
-Download latest Android NDK from official website and set NDK path.
+Download the latest [Android NDK](https://developer.android.com/ndk/downloads) from the official website and set NDK path.
 ```
-$ export PATH="$PATH:/PATH-TO-ANDROID-NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/"
-$ scons platform=android generate_bindings=yes
+$ scons platform=android generate_bindings=yes ANDROID_NDK_ROOT="/PATH-TO-ANDROID-NDK/" android_arch=<  >
 ```
-you can also specify architecture by enabling bits=64 (or 32) default is 64
+`android_arch` can be `armv7, arm64v8, x86, x86_64`.
+`ANDROID_NDK_ROOT` can also be set in the environment variables of your computer if you do not want to include it in your Scons call.
 
 
 > Replace `<your platform>` with either `windows`, `linux`, `osx` or `android`.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,16 @@ $ cd godot-cpp
 $ scons platform=<your platform> generate_bindings=yes
 $ cd ..
 ```
+For android:
+Download latest Android NDK from official website and set NDK path.
+```
+$ export PATH="$PATH:/PATH-TO-ANDROID-NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/"
+$ scons platform=android generate_bindings=yes
+```
+you can also specify architecture by enabling bits=64 (or 32) default is 64
 
-> Replace `<your platform>` with either `windows`, `linux` or `osx`.
+
+> Replace `<your platform>` with either `windows`, `linux`, `osx` or `android`.
 
 > Include `use_llvm=yes` for using clang++
 
@@ -188,6 +196,19 @@ $ link /nologo /dll /out:bin\libtest.dll /implib:bin\libsimple.lib src\init.obj 
 
 *macOS*
 For OSX you need to find out what compiler flags need to be used.
+
+*Android*
+```
+$ cd SimpleLibrary
+$ aarch64-linux-android29-clang -fPIC -o src/init.os -c src/init.cpp -g -O3 -std=c++14 -Igodot-cpp/include -Igodot-cpp/include/core -Igodot-cpp/include/gen -Igodot-cpp/godot_headers
+$ aarch64-linux-android29-clang -o bin/libtest.so -shared src/init.os -Lgodot-cpp/bin -l<name of the godot-cpp>
+```
+> use `armv7a-linux-androideabi29-clang` for 32 bit armeabi-v7a library
+
+> This creates the file `libtest.so` in your `SimpleLibrary/bin` directory.
+
+> You will need to replace `<name of the godot-cpp>` with the file that was created in [**Compiling the cpp bindings library**](#compiling-the-cpp-bindings-library)
+
 
 ### Creating `.gdnlib` and `.gdns` files
 follow [godot_header/README.md](https://github.com/GodotNativeTools/godot_headers/blob/master/README.md#how-do-i-use-native-scripts-from-the-editor) to create the `.gdns` 


### PR DESCRIPTION
This PR adds the ability to compile for the various Android architectures using the Android NDK toolchain. The following Scons options have been added:
- `android_arch`: The target Android architecture to compile for. Allowed values: `armv7, arm64v8, x86, x86_64`
- `android_api_level`: The Android API level to target (defaults to `18` for 32-bit architectures, `21` for 64-bit)
- `ANDROID_NDK_ROOT`: The path to an Android NDK installation on your machine. By default, fetches from the system's environment variables.

The only requirement is that the user download the [Android NDK](https://developer.android.com/ndk/downloads).

This branch has been tested on Windows, Linux and OSX using my [nightly CI build](https://travis-ci.com/TGRCdev/gdsqlite-native) of Godot's [SQLite plugin](https://github.com/khairul169/gdsqlite-native). The [resulting binaries](https://github.com/TGRCdev/gdsqlite-native/releases/tag/nightly-1) were tested on a Samsung S10E.

Thank you @Jayanth-L for the [original work](https://github.com/GodotNativeTools/godot-cpp/pull/319) that I built off of. Before this, I had absolutely no knowledge of the NDK toolchain, and their commit pushed me in the right direction.
