### PR TITLE
Fix String::operator+ memory leak

### DIFF
--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -124,8 +124,8 @@ bool String::operator!=(const String &s) const {
 }
 
 String String::operator+(const String &s) const {
-	String new_string = *this;
-	new_string._godot_string = godot::api->godot_string_operator_plus(&new_string._godot_string, &s._godot_string);
+	String new_string;
+	new_string._godot_string = godot::api->godot_string_operator_plus(&_godot_string, &s._godot_string);
 
 	return new_string;
 }


### PR DESCRIPTION
Fixes godotengine/godot#32502.

`new_string` was adding a reference to `this` without removing it.

It looks like #307 also fixes this leak by cleaning up the way the underlying `godot_string` is accessed. Not sure if there's a reason it wasn't merged 2 months ago, but if the cleaner style is preferred, that one should be merged instead.