### PR TITLE
Add godot namespace to references in Defs macros.

### DIFF
--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -91,7 +91,7 @@ typedef float real_t;
 
 // ERR/WARN macros
 #ifndef WARN_PRINT
-#define WARN_PRINT(msg) Godot::print_warning(msg, __func__, __FILE__, __LINE__)
+#define WARN_PRINT(msg) godot::Godot::print_warning(msg, __func__, __FILE__, __LINE__)
 #endif
 
 #ifndef WARN_PRINTS
@@ -99,7 +99,7 @@ typedef float real_t;
 #endif
 
 #ifndef ERR_PRINT
-#define ERR_PRINT(msg) Godot::print_error(msg, __func__, __FILE__, __LINE__)
+#define ERR_PRINT(msg) godot::Godot::print_error(msg, __func__, __FILE__, __LINE__)
 #endif
 
 #ifndef ERR_PRINTS
@@ -107,19 +107,19 @@ typedef float real_t;
 #endif
 
 #ifndef FATAL_PRINT
-#define FATAL_PRINT(msg) ERR_PRINT(String("FATAL: ") + (msg))
+#define FATAL_PRINT(msg) ERR_PRINT(godot::String("FATAL: ") + (msg))
 #endif
 
 #ifndef ERR_MSG_INDEX
-#define ERR_MSG_INDEX(index, size) (String("Index ") + #index + "=" + String::num_int64(index) + " out of size (" + #size + "=" + String::num_int64(size) + ")")
+#define ERR_MSG_INDEX(index, size) (godot::String("Index ") + #index + "=" + godot::String::num_int64(index) + " out of size (" + #size + "=" + godot::String::num_int64(size) + ")")
 #endif
 
 #ifndef ERR_MSG_NULL
-#define ERR_MSG_NULL(param) (String("Parameter '") + #param + "' is null.")
+#define ERR_MSG_NULL(param) (godot::String("Parameter '") + #param + "' is null.")
 #endif
 
 #ifndef ERR_MSG_COND
-#define ERR_MSG_COND(cond) (String("Condition '") + #cond + "' is true.")
+#define ERR_MSG_COND(cond) (godot::String("Condition '") + #cond + "' is true.")
 #endif
 
 #ifndef ERR_FAIL_INDEX


### PR DESCRIPTION
Was causing failed builds when used outside of the godot namespace.