### PR TITLE
Fix memory leak when using Ref::instance()

### DIFF
--- a/include/core/Ref.hpp
+++ b/include/core/Ref.hpp
@@ -187,7 +187,8 @@ public:
 
 	void instance() {
 		//ref(memnew(T));
-		ref(T::_new());
+		unref();
+		reference = T::_new();
 	}
 
 	Ref() {


### PR DESCRIPTION
This should fix #215. Using Ref like this:
```
Ref<A> a;
a.instance();
```
with a custom type A should no longer create a memory leak. At least in my little project it works.