### PR TITLE
[Android] Use ranlib and linker form the Android toolchain.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -278,6 +278,8 @@ elif env['platform'] == 'android':
     env['CC'] = toolchain + "/bin/clang"
     env['CXX'] = toolchain + "/bin/clang++"
     env['AR'] = toolchain + "/bin/" + arch_info['tool_path'] + "-ar"
+    env['RANLIB'] = toolchain + "/bin/" + arch_info['tool_path'] + "-ranlib"
+    env['LINK'] = toolchain + "/bin/clang++"
 
     env.Append(CCFLAGS=['--target=' + arch_info['target'] + env['android_api_level'], '-march=' + arch_info['march'], '-fPIC'])#, '-fPIE', '-fno-addrsig', '-Oz'])
     env.Append(CCFLAGS=arch_info['ccflags'])


### PR DESCRIPTION
Use `ranlib` and linker form the Android toolchain instead of system default.
Fixes Android build on macOS (default `ranlib` produce empty static lib).