### PR TITLE
Added bounce to vector2.hpp

### DIFF
--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -176,6 +176,10 @@ struct Vector2 {
 		return p_vec - *this * this->dot(p_vec);
 	}
 
+	inline Vector2 bounce(const Vector2 &p_normal) const {
+		return -reflect(p_normal);
+	}
+
 	inline Vector2 reflect(const Vector2 &p_vec) const {
 		return p_vec - *this * this->dot(p_vec) * 2.0;
 	}


### PR DESCRIPTION
It seems like everything was implemented for supporting the bounce function, in:
**Godot itself:**
- Entry exists in 'modules/gdnative/gdnative/vector2.cpp'
- Entry exists in 'modules/gdnative/gdnative_api.json'
- Entry exists in 'modules/gdnative/include/gdnative/vector2.h'

**Godot Headers:**
- Entry exists 'gdnative/vector2.h'

However, the thing that was missing was to have an actual function in 'include/core/Vector2.hpp'
I added this (just a copy from Godot's bounce-function) as it was requested by #347

Some questions:
- Why are some functions defined in the header file (include/core/Vector2.hpp) and not in the source file (src/core/Vector2.cpp)?
- Should the Vector2-files in Godot-cpp be updated to include all of the missing functionalities?