### PR TITLE
Fixed cmake source file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,23 +132,46 @@ endif()
 
 # Generate source from the bindings file
 message(STATUS "Generating Bindings")
-execute_process(COMMAND "python" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_CUSTOM_API_FILE}\")"
+execute_process(COMMAND "python" "-c" "import binding_generator; binding_generator.print_file_list(\"${GODOT_CUSTOM_API_FILE}\", \"${CMAKE_CURRENT_BINARY_DIR}\", headers=True)"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	RESULT_VARIABLE GENERATION_RESULT
-	OUTPUT_VARIABLE GENERATION_OUTPUT)
-message(STATUS ${GENERATION_RESULT} ${GENERATION_OUTPUT})
+	RESULT_VARIABLE HEADERS_FILE_LIST_RESULT
+	OUTPUT_VARIABLE HEADERS_FILE_LIST
+)
+set(HEADERS_FILE_LIST ${HEADERS_FILE_LIST})
+
+execute_process(COMMAND "python" "-c" "import binding_generator; binding_generator.print_file_list(\"${GODOT_CUSTOM_API_FILE}\", \"${CMAKE_CURRENT_BINARY_DIR}\", sources=True)"
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	RESULT_VARIABLE SOURCES_FILE_LIST_RESULT
+	OUTPUT_VARIABLE SOURCES_FILE_LIST
+)
+set(SOURCES_FILE_LIST ${SOURCES_FILE_LIST})
+
+add_custom_command(OUTPUT ${HEADERS_FILE_LIST} ${SOURCES_FILE_LIST}
+		COMMAND "python" "-c" "import binding_generator; binding_generator.generate_bindings('${GODOT_CUSTOM_API_FILE}','${CMAKE_CURRENT_BINARY_DIR}')"
+		VERBATIM
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		MAIN_DEPENDENCY ${GODOT_CUSTOM_API_FILE}
+		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/binding_generator.py
+		COMMENT Generating Bindings
+)
 
 # Get Sources
 file(GLOB_RECURSE SOURCES src/*.c**)
 file(GLOB_RECURSE HEADERS include/*.h**)
 
 # Define our godot-cpp library
-add_library(${PROJECT_NAME} ${SOURCES} ${HEADERS})
+add_library(${PROJECT_NAME}
+		${SOURCES}
+		${SOURCES_FILE_LIST}
+		${HEADERS}
+		${HEADERS_FILE_LIST}
+)
 target_include_directories(${PROJECT_NAME}
 	PUBLIC
 	include
 	include/core
 	include/gen
+	${CMAKE_CURRENT_BINARY_DIR}/include/gen/
 )
 
 # Put godot headers as SYSTEM PUBLIC to exclude warnings from irrelevant headers

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -102,7 +102,7 @@ def generate_class_header(used_classes, c):
     source.append("")
 
     source.append("#include <gdnative_api_struct.gen.h>")
-    source.append("#include <stdint.h>")
+    source.append("#include <cstdint>")
     source.append("")
 
 

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1,41 +1,68 @@
 #!/usr/bin/env python
-
 import json
-
-# comment.
+import os
 
 classes = []
 
-def generate_bindings(path):
 
+def print_file_list(api_filepath: str, output_dir: str, headers=False, sources=False):
     global classes
-    classes = json.load(open(path))
+    end = ';'
+    with open(api_filepath) as api_file:
+        classes = json.load(api_file)
+    include_gen_folder = os.path.join(output_dir, 'include', 'gen')
+    source_gen_folder = os.path.join(output_dir, 'src', 'gen')
+    for _class in classes:
+        header_filename = os.path.join(include_gen_folder, strip_name(_class["name"]) + ".hpp")
+        source_filename = os.path.join(source_gen_folder, strip_name(_class["name"]) + ".cpp")
+        headers and print(header_filename, end=end)
+        sources and print(source_filename, end=end)
+    icall_header_filename = os.path.join(include_gen_folder, '__icalls.hpp')
+    register_types_filename = os.path.join(source_gen_folder, '__register_types.cpp')
+    init_method_bindings_filename = os.path.join(source_gen_folder, '__init_method_bindings.cpp')
+    headers and print(icall_header_filename, end=end)
+    sources and print(register_types_filename, end=end)
+    sources and print(init_method_bindings_filename, end=end)
+
+
+def generate_bindings(api_filepath: str, output_dir: str):
+    global classes
+    with open(api_filepath) as api_file:
+        classes = json.load(api_file)
 
     icalls = set()
+    include_gen_folder = os.path.join(output_dir, 'include', 'gen')
+    source_gen_folder = os.path.join(output_dir, 'src', 'gen')
+    os.makedirs(include_gen_folder, exist_ok=True)
+    os.makedirs(source_gen_folder, exist_ok=True)
 
     for c in classes:
-        # print c['name']
+        # print(c['name'])
         used_classes = get_used_classes(c)
 
         header = generate_class_header(used_classes, c)
 
         impl = generate_class_implementation(icalls, used_classes, c)
 
-        header_file = open("include/gen/" + strip_name(c["name"]) + ".hpp", "w+")
-        header_file.write(header)
+        header_filename = os.path.join(include_gen_folder, strip_name(c["name"]) + ".hpp")
+        with open(header_filename, "w+") as header_file:
+            header_file.write(header)
 
-        source_file = open("src/gen/" + strip_name(c["name"]) + ".cpp", "w+")
-        source_file.write(impl)
+        source_filename = os.path.join(source_gen_folder, strip_name(c["name"]) + ".cpp")
+        with open(source_filename, "w+") as source_file:
+            source_file.write(impl)
 
+    icall_header_filename = os.path.join(include_gen_folder, '__icalls.hpp')
+    with open(icall_header_filename, "w+") as icall_header_file:
+        icall_header_file.write(generate_icall_header(icalls))
 
-    icall_header_file = open("include/gen/__icalls.hpp", "w+")
-    icall_header_file.write(generate_icall_header(icalls))
+    register_types_filename = os.path.join(source_gen_folder, '__register_types.cpp')
+    with open(register_types_filename, "w+") as register_types_file:
+        register_types_file.write(generate_type_registry(classes))
 
-    register_types_file = open("src/gen/__register_types.cpp", "w+")
-    register_types_file.write(generate_type_registry(classes))
-
-    init_method_bindings_file = open("src/gen/__init_method_bindings.cpp", "w+")
-    init_method_bindings_file.write(generate_init_method_bindings(classes))
+    init_method_bindings_filename = os.path.join(source_gen_folder, '__init_method_bindings.cpp')
+    with open(init_method_bindings_filename, "w+") as init_method_bindings_file:
+        init_method_bindings_file.write(generate_init_method_bindings(classes))
 
 
 def is_reference_type(t):

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -15,14 +15,18 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
     for _class in classes:
         header_filename = os.path.join(include_gen_folder, strip_name(_class["name"]) + ".hpp")
         source_filename = os.path.join(source_gen_folder, strip_name(_class["name"]) + ".cpp")
-        headers and print(header_filename, end=end)
-        sources and print(source_filename, end=end)
+        if headers:
+            print(header_filename, end=end)
+        if sources:
+            print(source_filename, end=end)
     icall_header_filename = os.path.join(include_gen_folder, '__icalls.hpp')
     register_types_filename = os.path.join(source_gen_folder, '__register_types.cpp')
     init_method_bindings_filename = os.path.join(source_gen_folder, '__init_method_bindings.cpp')
-    headers and print(icall_header_filename, end=end)
-    sources and print(register_types_filename, end=end)
-    sources and print(init_method_bindings_filename, end=end)
+    if headers:
+        print(icall_header_filename, end=end)
+    if sources:
+        print(register_types_filename, end=end)
+        print(init_method_bindings_filename, end=end)
 
 
 def generate_bindings(api_filepath, output_dir):

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -5,7 +5,7 @@ import os
 classes = []
 
 
-def print_file_list(api_filepath: str, output_dir: str, headers=False, sources=False):
+def print_file_list(api_filepath, output_dir, headers=False, sources=False):
     global classes
     end = ';'
     with open(api_filepath) as api_file:
@@ -25,7 +25,7 @@ def print_file_list(api_filepath: str, output_dir: str, headers=False, sources=F
     sources and print(init_method_bindings_filename, end=end)
 
 
-def generate_bindings(api_filepath: str, output_dir: str):
+def generate_bindings(api_filepath, output_dir):
     global classes
     with open(api_filepath) as api_file:
         classes = json.load(api_file)


### PR DESCRIPTION
I needed to fix the file generation in the `CMakeLists.txt` for my own project.

The file generation currently regenerates sources and headers every time any `CMakeLists.txt` is modified and it takes a long time to recompile. With my modification the generation happens only when necessary.

Another thing I needed to modify is that the generation of any intermediate file should go into the build folder, not into the source folder. For this I needed to modify the `binding_generator.py`.

If you need me to modify/improve anything of this pull request don't hesitate to ask. 