### PR TITLE
Vector2 reflection amendment

### DIFF
--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -181,7 +181,7 @@ struct Vector2 {
 	}
 
 	inline Vector2 reflect(const Vector2 &p_vec) const {
-		return p_vec - *this * this->dot(p_vec) * 2.0;
+		return *this - p_vec * this->dot(p_vec) * 2.0;
 	}
 
 	inline real_t angle() const {


### PR DESCRIPTION
Formula for Vector2 reflection with respect to a normal was incorrect. Corrected from:
<img src="https://latex.codecogs.com/gif.latex?r&space;=&space;n&space;-&space;2(d\cdot&space;n)d" title="r = n - 2(d\cdot n)d" />
to:
<img src="https://latex.codecogs.com/gif.latex?r&space;=&space;d&space;-&space;2(d\cdot&space;n)n" title="r = d - 2(d\cdot n)n" />
Where _r_ is the reflected vector, _d_ the incoming vector and _n_ the normal vector of the surface.
