### PR TITLE
Fix alloca() not being included on some platforms

### DIFF
--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -61,6 +61,11 @@ enum class Error {
 
 #include <GodotGlobal.hpp>
 
+// alloca() is non-standard. When using MSVC, it's in malloc.h.
+#if defined(__linux__) || defined(__APPLE__) || defined(__MINGW32__)
+#include <alloca.h>
+#endif
+
 typedef float real_t;
 
 #define CMP_EPSILON 0.00001


### PR DESCRIPTION
Should fix https://github.com/GodotNativeTools/godot-cpp/issues/376.
The place is similar to Godot, which adds it as part of `platform_config.h`.