### PR TITLE
Rename interface to gdn_interface because it's a defined keyword

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -499,58 +499,58 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
     if "constructors" in builtin_api:
         for constructor in builtin_api["constructors"]:
             result.append(
-                f'\t_method_bindings.constructor_{constructor["index"]} = internal::interface->variant_get_ptr_constructor({enum_type_name}, {constructor["index"]});'
+                f'\t_method_bindings.constructor_{constructor["index"]} = internal::gdn_interface->variant_get_ptr_constructor({enum_type_name}, {constructor["index"]});'
             )
 
     if builtin_api["has_destructor"]:
         result.append(
-            f"\t_method_bindings.destructor = internal::interface->variant_get_ptr_destructor({enum_type_name});"
+            f"\t_method_bindings.destructor = internal::gdn_interface->variant_get_ptr_destructor({enum_type_name});"
         )
 
     if "methods" in builtin_api:
         for method in builtin_api["methods"]:
             # TODO: Add error check for hash mismatch.
             result.append(
-                f'\t_method_bindings.method_{method["name"]} = internal::interface->variant_get_ptr_builtin_method({enum_type_name}, "{method["name"]}", {method["hash"]});'
+                f'\t_method_bindings.method_{method["name"]} = internal::gdn_interface->variant_get_ptr_builtin_method({enum_type_name}, "{method["name"]}", {method["hash"]});'
             )
 
     if "members" in builtin_api:
         for member in builtin_api["members"]:
             result.append(
-                f'\t_method_bindings.member_{member["name"]}_setter = internal::interface->variant_get_ptr_setter({enum_type_name}, "{member["name"]}");'
+                f'\t_method_bindings.member_{member["name"]}_setter = internal::gdn_interface->variant_get_ptr_setter({enum_type_name}, "{member["name"]}");'
             )
             result.append(
-                f'\t_method_bindings.member_{member["name"]}_getter = internal::interface->variant_get_ptr_getter({enum_type_name}, "{member["name"]}");'
+                f'\t_method_bindings.member_{member["name"]}_getter = internal::gdn_interface->variant_get_ptr_getter({enum_type_name}, "{member["name"]}");'
             )
 
     if "indexing_return_type" in builtin_api:
         result.append(
-            f"\t_method_bindings.indexed_setter = internal::interface->variant_get_ptr_indexed_setter({enum_type_name});"
+            f"\t_method_bindings.indexed_setter = internal::gdn_interface->variant_get_ptr_indexed_setter({enum_type_name});"
         )
         result.append(
-            f"\t_method_bindings.indexed_getter = internal::interface->variant_get_ptr_indexed_getter({enum_type_name});"
+            f"\t_method_bindings.indexed_getter = internal::gdn_interface->variant_get_ptr_indexed_getter({enum_type_name});"
         )
 
     if "is_keyed" in builtin_api and builtin_api["is_keyed"]:
         result.append(
-            f"\t_method_bindings.keyed_setter = internal::interface->variant_get_ptr_keyed_setter({enum_type_name});"
+            f"\t_method_bindings.keyed_setter = internal::gdn_interface->variant_get_ptr_keyed_setter({enum_type_name});"
         )
         result.append(
-            f"\t_method_bindings.keyed_getter = internal::interface->variant_get_ptr_keyed_getter({enum_type_name});"
+            f"\t_method_bindings.keyed_getter = internal::gdn_interface->variant_get_ptr_keyed_getter({enum_type_name});"
         )
         result.append(
-            f"\t_method_bindings.keyed_checker = internal::interface->variant_get_ptr_keyed_checker({enum_type_name});"
+            f"\t_method_bindings.keyed_checker = internal::gdn_interface->variant_get_ptr_keyed_checker({enum_type_name});"
         )
 
     if "operators" in builtin_api:
         for operator in builtin_api["operators"]:
             if "right_type" in operator:
                 result.append(
-                    f'\t_method_bindings.operator_{get_operator_id_name(operator["name"])}_{operator["right_type"]} = internal::interface->variant_get_ptr_operator_evaluator(GDNATIVE_VARIANT_OP_{get_operator_id_name(operator["name"]).upper()}, {enum_type_name}, GDNATIVE_VARIANT_TYPE_{camel_to_snake(operator["right_type"]).upper()});'
+                    f'\t_method_bindings.operator_{get_operator_id_name(operator["name"])}_{operator["right_type"]} = internal::gdn_interface->variant_get_ptr_operator_evaluator(GDNATIVE_VARIANT_OP_{get_operator_id_name(operator["name"]).upper()}, {enum_type_name}, GDNATIVE_VARIANT_TYPE_{camel_to_snake(operator["right_type"]).upper()});'
                 )
             else:
                 result.append(
-                    f'\t_method_bindings.operator_{get_operator_id_name(operator["name"])} = internal::interface->variant_get_ptr_operator_evaluator(GDNATIVE_VARIANT_OP_{get_operator_id_name(operator["name"]).upper()}, {enum_type_name}, GDNATIVE_VARIANT_TYPE_NIL);'
+                    f'\t_method_bindings.operator_{get_operator_id_name(operator["name"])} = internal::gdn_interface->variant_get_ptr_operator_evaluator(GDNATIVE_VARIANT_OP_{get_operator_id_name(operator["name"]).upper()}, {enum_type_name}, GDNATIVE_VARIANT_TYPE_NIL);'
                 )
 
     result.append("}")
@@ -1012,13 +1012,13 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
     if is_singleton:
         result.append(f"{class_name} *{class_name}::get_singleton() {{")
         result.append(
-            f'\tstatic GDNativeObjectPtr singleton_obj = internal::interface->global_get_singleton("{class_name}");'
+            f'\tstatic GDNativeObjectPtr singleton_obj = internal::gdn_interface->global_get_singleton("{class_name}");'
         )
         result.append("#ifdef DEBUG_ENABLED")
         result.append("\tERR_FAIL_COND_V(singleton_obj == nullptr, nullptr);")
         result.append("#endif // DEBUG_ENABLED")
         result.append(
-            f"\tstatic {class_name} *singleton = reinterpret_cast<{class_name} *>(internal::interface->object_get_instance_binding(singleton_obj, internal::token, &{class_name}::___binding_callbacks));"
+            f"\tstatic {class_name} *singleton = reinterpret_cast<{class_name} *>(internal::gdn_interface->object_get_instance_binding(singleton_obj, internal::token, &{class_name}::___binding_callbacks));"
         )
         result.append("\treturn singleton;")
         result.append("}")
@@ -1038,7 +1038,7 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
 
             # Method body.
             result.append(
-                f'\tstatic GDNativeMethodBindPtr ___method_bind = internal::interface->classdb_get_method_bind("{class_name}", "{method["name"]}", {method["hash"]});'
+                f'\tstatic GDNativeMethodBindPtr ___method_bind = internal::gdn_interface->classdb_get_method_bind("{class_name}", "{method["name"]}", {method["hash"]});'
             )
             method_call = "\t"
             has_return = "return_value" in method and method["return_value"]["type"] != "void"
@@ -1080,7 +1080,7 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
             else:  # vararg.
                 result.append("\tGDNativeCallError error;")
                 result.append("\tVariant ret;")
-                method_call += "internal::interface->object_method_bind_call(___method_bind, _owner, (const GDNativeVariantPtr *)args, arg_count, &ret, &error"
+                method_call += "internal::gdn_interface->object_method_bind_call(___method_bind, _owner, (const GDNativeVariantPtr *)args, arg_count, &ret, &error"
 
             if is_ref:
                 method_call += ")"  # Close Ref<> constructor.
@@ -1231,7 +1231,7 @@ def generate_utility_functions(api, output_dir):
         # Function body.
 
         source.append(
-            f'\tstatic GDNativePtrUtilityFunction ___function = internal::interface->variant_get_ptr_utility_function("{function["name"]}", {function["hash"]});'
+            f'\tstatic GDNativePtrUtilityFunction ___function = internal::gdn_interface->variant_get_ptr_utility_function("{function["name"]}", {function["hash"]});'
         )
         has_return = "return_type" in function and function["return_type"] != "void"
         if has_return:

--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -240,7 +240,7 @@ public:
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		return Ref<T>(godot::internal::interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
+		return Ref<T>(godot::internal::gdn_interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
 	}
 
 	typedef Ref<T> EncodeT;
@@ -255,7 +255,7 @@ struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		return Ref<T>(godot::internal::interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
+		return Ref<T>(godot::internal::gdn_interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
 	}
 };
 

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -94,126 +94,126 @@ struct Creator<T, typename std::enable_if<std::is_base_of_v<godot::Wrapped, T>>:
 #define CHECK_CLASS_CONSTRUCTOR(m_constructor, m_class)
 #endif
 
-#define GDCLASS(m_class, m_inherits)                                                                                                                              \
-private:                                                                                                                                                          \
-	friend class ClassDB;                                                                                                                                         \
-                                                                                                                                                                  \
-	using SelfType = m_class;                                                                                                                                     \
-                                                                                                                                                                  \
-protected:                                                                                                                                                        \
-	static void (*_get_bind_methods())() {                                                                                                                        \
-		return &m_class::_bind_methods;                                                                                                                           \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	template <class T>                                                                                                                                            \
-	static void register_virtuals() {                                                                                                                             \
-		m_inherits::register_virtuals<T>();                                                                                                                       \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-public:                                                                                                                                                           \
-	static void initialize_class() {                                                                                                                              \
-		static bool initialized = false;                                                                                                                          \
-		if (initialized) {                                                                                                                                        \
-			return;                                                                                                                                               \
-		}                                                                                                                                                         \
-		m_inherits::initialize_class();                                                                                                                           \
-		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                                                    \
-			_bind_methods();                                                                                                                                      \
-			m_inherits::register_virtuals<m_class>();                                                                                                             \
-		}                                                                                                                                                         \
-		initialized = true;                                                                                                                                       \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static const char *get_class_static() {                                                                                                                       \
-		return #m_class;                                                                                                                                          \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static const char *get_parent_class_static() {                                                                                                                \
-		return #m_inherits;                                                                                                                                       \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static GDExtensionClassInstancePtr create(void *data) {                                                                                                       \
-		return reinterpret_cast<GDExtensionClassInstancePtr>(new ("") m_class);                                                                                   \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                                                               \
-		if (ptr) {                                                                                                                                                \
-			m_class *cls = reinterpret_cast<m_class *>(ptr);                                                                                                      \
-			cls->~m_class();                                                                                                                                      \
-			::godot::Memory::free_static(cls);                                                                                                                    \
-		}                                                                                                                                                         \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static void set_object_instance(GDExtensionClassInstancePtr p_instance, GDNativeObjectPtr p_object_instance) {                                                \
-		godot::internal::interface->object_set_instance_binding(p_object_instance, godot::internal::token, p_instance, &m_class::___binding_callbacks);           \
-		reinterpret_cast<m_class *>(p_instance)->_owner = reinterpret_cast<godot::GodotObject *>(p_object_instance);                                              \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static void *___binding_create_callback(void *p_token, void *p_instance) {                                                                                    \
-		return nullptr;                                                                                                                                           \
-	}                                                                                                                                                             \
-	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                      \
-	}                                                                                                                                                             \
-	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) {                                                \
-		return true;                                                                                                                                              \
-	}                                                                                                                                                             \
-	static constexpr GDNativeInstanceBindingCallbacks ___binding_callbacks = {                                                                                    \
-		___binding_create_callback,                                                                                                                               \
-		___binding_free_callback,                                                                                                                                 \
-		___binding_reference_callback,                                                                                                                            \
-	};                                                                                                                                                            \
-                                                                                                                                                                  \
-	static m_class *_new() {                                                                                                                                      \
-		static GDNativeExtensionPtr ___extension = nullptr;                                                                                                       \
-		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class, &___extension);                            \
-		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                         \
-		GDNativeObjectPtr obj = godot::internal::interface->classdb_construct_object(___constructor, ___extension);                                               \
-		return reinterpret_cast<m_class *>(godot::internal::interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
+#define GDCLASS(m_class, m_inherits)                                                                                                                                  \
+private:                                                                                                                                                              \
+	friend class ClassDB;                                                                                                                                             \
+                                                                                                                                                                      \
+	using SelfType = m_class;                                                                                                                                         \
+                                                                                                                                                                      \
+protected:                                                                                                                                                            \
+	static void (*_get_bind_methods())() {                                                                                                                            \
+		return &m_class::_bind_methods;                                                                                                                               \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	template <class T>                                                                                                                                                \
+	static void register_virtuals() {                                                                                                                                 \
+		m_inherits::register_virtuals<T>();                                                                                                                           \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+public:                                                                                                                                                               \
+	static void initialize_class() {                                                                                                                                  \
+		static bool initialized = false;                                                                                                                              \
+		if (initialized) {                                                                                                                                            \
+			return;                                                                                                                                                   \
+		}                                                                                                                                                             \
+		m_inherits::initialize_class();                                                                                                                               \
+		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                                                        \
+			_bind_methods();                                                                                                                                          \
+			m_inherits::register_virtuals<m_class>();                                                                                                                 \
+		}                                                                                                                                                             \
+		initialized = true;                                                                                                                                           \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static const char *get_class_static() {                                                                                                                           \
+		return #m_class;                                                                                                                                              \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static const char *get_parent_class_static() {                                                                                                                    \
+		return #m_inherits;                                                                                                                                           \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static GDExtensionClassInstancePtr create(void *data) {                                                                                                           \
+		return reinterpret_cast<GDExtensionClassInstancePtr>(new ("") m_class);                                                                                       \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                                                                   \
+		if (ptr) {                                                                                                                                                    \
+			m_class *cls = reinterpret_cast<m_class *>(ptr);                                                                                                          \
+			cls->~m_class();                                                                                                                                          \
+			::godot::Memory::free_static(cls);                                                                                                                        \
+		}                                                                                                                                                             \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static void set_object_instance(GDExtensionClassInstancePtr p_instance, GDNativeObjectPtr p_object_instance) {                                                    \
+		godot::internal::gdn_interface->object_set_instance_binding(p_object_instance, godot::internal::token, p_instance, &m_class::___binding_callbacks);           \
+		reinterpret_cast<m_class *>(p_instance)->_owner = reinterpret_cast<godot::GodotObject *>(p_object_instance);                                                  \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static void *___binding_create_callback(void *p_token, void *p_instance) {                                                                                        \
+		return nullptr;                                                                                                                                               \
+	}                                                                                                                                                                 \
+	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                          \
+	}                                                                                                                                                                 \
+	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) {                                                    \
+		return true;                                                                                                                                                  \
+	}                                                                                                                                                                 \
+	static constexpr GDNativeInstanceBindingCallbacks ___binding_callbacks = {                                                                                        \
+		___binding_create_callback,                                                                                                                                   \
+		___binding_free_callback,                                                                                                                                     \
+		___binding_reference_callback,                                                                                                                                \
+	};                                                                                                                                                                \
+                                                                                                                                                                      \
+	static m_class *_new() {                                                                                                                                          \
+		static GDNativeExtensionPtr ___extension = nullptr;                                                                                                           \
+		static GDNativeClassConstructor ___constructor = godot::internal::gdn_interface->classdb_get_constructor(#m_class, &___extension);                            \
+		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                             \
+		GDNativeObjectPtr obj = godot::internal::gdn_interface->classdb_construct_object(___constructor, ___extension);                                               \
+		return reinterpret_cast<m_class *>(godot::internal::gdn_interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
 private:
 
 // Don't use this for your classes, use GDCLASS() instead.
-#define GDNATIVE_CLASS(m_class, m_inherits)                                                                                                                       \
-protected:                                                                                                                                                        \
-	static void (*_get_bind_methods())() {                                                                                                                        \
-		return nullptr;                                                                                                                                           \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-public:                                                                                                                                                           \
-	static void initialize_class() {}                                                                                                                             \
-                                                                                                                                                                  \
-	static const char *get_class_static() {                                                                                                                       \
-		return #m_class;                                                                                                                                          \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static const char *get_parent_class_static() {                                                                                                                \
-		return #m_inherits;                                                                                                                                       \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
-	static void *___binding_create_callback(void *p_token, void *p_instance) {                                                                                    \
-		m_class *obj = new ("") m_class;                                                                                                                          \
-		obj->_owner = (godot::GodotObject *)p_instance;                                                                                                           \
-		return obj;                                                                                                                                               \
-	}                                                                                                                                                             \
-	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                      \
-		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                                                              \
-	}                                                                                                                                                             \
-	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) {                                                \
-		return true;                                                                                                                                              \
-	}                                                                                                                                                             \
-	static constexpr GDNativeInstanceBindingCallbacks ___binding_callbacks = {                                                                                    \
-		___binding_create_callback,                                                                                                                               \
-		___binding_free_callback,                                                                                                                                 \
-		___binding_reference_callback,                                                                                                                            \
-	};                                                                                                                                                            \
-	static m_class *_new() {                                                                                                                                      \
-		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class, nullptr);                                  \
-		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                         \
-		GDNativeObjectPtr obj = ___constructor();                                                                                                                 \
-		return reinterpret_cast<m_class *>(godot::internal::interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \
-	}                                                                                                                                                             \
-                                                                                                                                                                  \
+#define GDNATIVE_CLASS(m_class, m_inherits)                                                                                                                           \
+protected:                                                                                                                                                            \
+	static void (*_get_bind_methods())() {                                                                                                                            \
+		return nullptr;                                                                                                                                               \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+public:                                                                                                                                                               \
+	static void initialize_class() {}                                                                                                                                 \
+                                                                                                                                                                      \
+	static const char *get_class_static() {                                                                                                                           \
+		return #m_class;                                                                                                                                              \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static const char *get_parent_class_static() {                                                                                                                    \
+		return #m_inherits;                                                                                                                                           \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
+	static void *___binding_create_callback(void *p_token, void *p_instance) {                                                                                        \
+		m_class *obj = new ("") m_class;                                                                                                                              \
+		obj->_owner = (godot::GodotObject *)p_instance;                                                                                                               \
+		return obj;                                                                                                                                                   \
+	}                                                                                                                                                                 \
+	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                          \
+		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                                                                  \
+	}                                                                                                                                                                 \
+	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) {                                                    \
+		return true;                                                                                                                                                  \
+	}                                                                                                                                                                 \
+	static constexpr GDNativeInstanceBindingCallbacks ___binding_callbacks = {                                                                                        \
+		___binding_create_callback,                                                                                                                                   \
+		___binding_free_callback,                                                                                                                                     \
+		___binding_reference_callback,                                                                                                                                \
+	};                                                                                                                                                                \
+	static m_class *_new() {                                                                                                                                          \
+		static GDNativeClassConstructor ___constructor = godot::internal::gdn_interface->classdb_get_constructor(#m_class, nullptr);                                  \
+		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                             \
+		GDNativeObjectPtr obj = ___constructor();                                                                                                                     \
+		return reinterpret_cast<m_class *>(godot::internal::gdn_interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \
+	}                                                                                                                                                                 \
+                                                                                                                                                                      \
 private:
 
 #endif // ! GODOT_CPP_WRAPPED_HPP

--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -106,7 +106,7 @@ template <class T>
 struct VariantCasterAndValidate {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, GDNativeCallError &r_error) {
 		GDNativeVariantType argtype = GetTypeInfo<T>::VARIANT_TYPE;
-		if (!internal::interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
+		if (!internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
 				!VariantObjectClassChecker<T>::check(p_args[p_arg_idx])) {
 			r_error.error = GDNATIVE_CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = p_arg_idx;
@@ -121,7 +121,7 @@ template <class T>
 struct VariantCasterAndValidate<T &> {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, GDNativeCallError &r_error) {
 		GDNativeVariantType argtype = GetTypeInfo<T>::VARIANT_TYPE;
-		if (!internal::interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
+		if (!internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
 				!VariantObjectClassChecker<T>::check(p_args[p_arg_idx])) {
 			r_error.error = GDNATIVE_CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = p_arg_idx;
@@ -136,7 +136,7 @@ template <class T>
 struct VariantCasterAndValidate<const T &> {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, GDNativeCallError &r_error) {
 		GDNativeVariantType argtype = GetTypeInfo<T>::VARIANT_TYPE;
-		if (!internal::interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
+		if (!internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
 				!VariantObjectClassChecker<T>::check(p_args[p_arg_idx])) {
 			r_error.error = GDNATIVE_CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = p_arg_idx;

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -163,7 +163,7 @@ void ClassDB::register_class() {
 		(void *)cl.name, //void *class_userdata;
 	};
 
-	internal::interface->classdb_register_extension_class(internal::library, cl.name, cl.parent_name, &class_info);
+	internal::gdn_interface->classdb_register_extension_class(internal::library, cl.name, cl.parent_name, &class_info);
 
 	// call bind_methods etc. to register all members of the class
 	T::initialize_class();

--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -47,22 +47,22 @@ template <class O, class... Args>
 O *_call_native_mb_ret_obj(const GDNativeMethodBindPtr mb, void *instance, const Args &...args) {
 	GodotObject *ret = nullptr;
 	std::array<const GDNativeTypePtr, sizeof...(Args)> mb_args = { { (const GDNativeTypePtr)args... } };
-	internal::interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), &ret);
-	return reinterpret_cast<O *>(internal::interface->object_get_instance_binding(ret, internal::token, &O::___binding_callbacks));
+	internal::gdn_interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), &ret);
+	return reinterpret_cast<O *>(internal::gdn_interface->object_get_instance_binding(ret, internal::token, &O::___binding_callbacks));
 }
 
 template <class R, class... Args>
 R _call_native_mb_ret(const GDNativeMethodBindPtr mb, void *instance, const Args &...args) {
 	R ret;
 	std::array<const GDNativeTypePtr, sizeof...(Args)> mb_args = { { (const GDNativeTypePtr)args... } };
-	internal::interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), &ret);
+	internal::gdn_interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), &ret);
 	return ret;
 }
 
 template <class... Args>
 void _call_native_mb_no_ret(const GDNativeMethodBindPtr mb, void *instance, const Args &...args) {
 	std::array<const GDNativeTypePtr, sizeof...(Args)> mb_args = { { (const GDNativeTypePtr)args... } };
-	internal::interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), nullptr);
+	internal::gdn_interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), nullptr);
 }
 
 template <class R, class... Args>
@@ -78,7 +78,7 @@ Object *_call_utility_ret_obj(const GDNativePtrUtilityFunction func, void *insta
 	GodotObject *ret = nullptr;
 	std::array<const GDNativeTypePtr, sizeof...(Args)> mb_args = { { (const GDNativeTypePtr)args... } };
 	func(&ret, mb_args.data(), mb_args.size());
-	return (Object *)internal::interface->object_get_instance_binding(ret, internal::token, &Object::___binding_callbacks);
+	return (Object *)internal::gdn_interface->object_get_instance_binding(ret, internal::token, &Object::___binding_callbacks);
 }
 
 template <class... Args>

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -90,7 +90,7 @@ void memdelete(T *p_class, typename std::enable_if<!std::is_base_of_v<godot::Wra
 
 template <class T, std::enable_if_t<std::is_base_of_v<godot::Wrapped, T>, bool> = true>
 void memdelete(T *p_class) {
-	godot::internal::interface->object_destroy(p_class->_owner);
+	godot::internal::gdn_interface->object_destroy(p_class->_owner);
 }
 
 #define memnew_arr(m_class, m_count) memnew_arr_template<m_class>(m_count)

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -165,7 +165,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <class T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return reinterpret_cast<T *>(godot::internal::interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
+		return reinterpret_cast<T *>(godot::internal::gdn_interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
@@ -176,7 +176,7 @@ struct PtrToArg<T *> {
 template <class T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		return reinterpret_cast<const T *>(godot::internal::interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
+		return reinterpret_cast<const T *>(godot::internal::gdn_interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -136,11 +136,11 @@ MethodInfo::MethodInfo(const PropertyInfo &p_ret, const char *p_name, const Args
 
 template <class T>
 T *Object::cast_to(Object *p_object) {
-	GDNativeObjectPtr casted = internal::interface->object_cast_to(p_object->_owner, internal::interface->classdb_get_class_tag(T::get_class_static()));
+	GDNativeObjectPtr casted = internal::gdn_interface->object_cast_to(p_object->_owner, internal::gdn_interface->classdb_get_class_tag(T::get_class_static()));
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<T *>(internal::interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return reinterpret_cast<T *>(internal::gdn_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
 }
 
 } // namespace godot

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -37,7 +37,7 @@ namespace godot {
 
 namespace internal {
 
-extern "C" const GDNativeInterface *interface;
+extern "C" const GDNativeInterface *gdn_interface;
 extern "C" GDNativeExtensionClassLibraryPtr library;
 extern "C" void *token;
 
@@ -59,13 +59,13 @@ public:
 	static void free_instance_callback(void *p_token, void *p_instance, void *p_binding);
 
 	class InitObject {
-		const GDNativeInterface *interface;
+		const GDNativeInterface *gdn_interface;
 		const GDNativeExtensionClassLibraryPtr library;
 		GDNativeInitialization *initialization;
 
 	public:
 		InitObject(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization) :
-				interface(p_interface),
+				gdn_interface(p_interface),
 				library(p_library),
 				initialization(r_initialization){};
 

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -55,13 +55,13 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1) {
 void ClassDB::add_property_group(const char *p_class, const char *p_name, const char *p_prefix) {
 	ERR_FAIL_COND_MSG(classes.find(p_class) == classes.end(), "Trying to add property to non-existing class.");
 
-	internal::interface->classdb_register_extension_class_property_group(internal::library, p_class, p_name, p_prefix);
+	internal::gdn_interface->classdb_register_extension_class_property_group(internal::library, p_class, p_name, p_prefix);
 }
 
 void ClassDB::add_property_subgroup(const char *p_class, const char *p_name, const char *p_prefix) {
 	ERR_FAIL_COND_MSG(classes.find(p_class) == classes.end(), "Trying to add property to non-existing class.");
 
-	internal::interface->classdb_register_extension_class_property_subgroup(internal::library, p_class, p_name, p_prefix);
+	internal::gdn_interface->classdb_register_extension_class_property_subgroup(internal::library, p_class, p_name, p_prefix);
 }
 
 void ClassDB::add_property(const char *p_class, const PropertyInfo &p_pinfo, const char *p_setter, const char *p_getter, int p_index) {
@@ -111,7 +111,7 @@ void ClassDB::add_property(const char *p_class, const PropertyInfo &p_pinfo, con
 	setget.index = p_index;
 	setget.type = p_pinfo.type;
 
-	internal::interface->classdb_register_extension_class_property(internal::library, info.name, &prop_info, setget.setter, setget.getter);
+	internal::gdn_interface->classdb_register_extension_class_property(internal::library, info.name, &prop_info, setget.setter, setget.getter);
 }
 
 MethodBind *ClassDB::get_method(const char *p_class, const char *p_method) {
@@ -193,7 +193,7 @@ void ClassDB::bind_method_godot(const char *p_class_name, MethodBind *p_method) 
 		p_method->get_hint_flags(), //uint32_t default_argument_count;
 		nullptr, //GDNativeVariantPtr *default_arguments;
 	};
-	internal::interface->classdb_register_extension_class_method(internal::library, p_class_name, &method_info);
+	internal::gdn_interface->classdb_register_extension_class_method(internal::library, p_class_name, &method_info);
 }
 
 void ClassDB::add_signal(const char *p_class, const MethodInfo &p_signal) {
@@ -228,7 +228,7 @@ void ClassDB::add_signal(const char *p_class, const MethodInfo &p_signal) {
 		});
 	}
 
-	internal::interface->classdb_register_extension_class_signal(internal::library, cl.name, p_signal.name, parameters.data(), parameters.size());
+	internal::gdn_interface->classdb_register_extension_class_signal(internal::library, cl.name, p_signal.name, parameters.data(), parameters.size());
 }
 
 void ClassDB::bind_integer_constant(const char *p_class_name, const char *p_enum_name, const char *p_constant_name, GDNativeInt p_constant_value) {
@@ -245,7 +245,7 @@ void ClassDB::bind_integer_constant(const char *p_class_name, const char *p_enum
 	type.constant_names.insert(p_constant_name);
 
 	// Register it with Godot
-	internal::interface->classdb_register_extension_class_integer_constant(internal::library, p_class_name, p_enum_name, p_constant_name, p_constant_value);
+	internal::gdn_interface->classdb_register_extension_class_integer_constant(internal::library, p_class_name, p_enum_name, p_constant_name, p_constant_value);
 }
 
 GDNativeExtensionClassCallVirtual ClassDB::get_virtual_func(void *p_userdata, const char *p_name) {
@@ -298,7 +298,7 @@ void ClassDB::deinitialize(GDNativeInitializationLevel p_level) {
 			continue;
 		}
 
-		internal::interface->classdb_unregister_extension_class(internal::library, cl.name);
+		internal::gdn_interface->classdb_unregister_extension_class(internal::library, cl.name);
 
 		for (auto method : cl.method_map) {
 			memdelete(method.second);

--- a/src/core/error_macros.cpp
+++ b/src/core/error_macros.cpp
@@ -38,9 +38,9 @@ namespace godot {
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, bool p_is_warning) {
 	if (p_is_warning) {
-		internal::interface->print_warning(p_message, p_function, p_file, p_line);
+		internal::gdn_interface->print_warning(p_message, p_function, p_file, p_line);
 	} else {
-		internal::interface->print_error(p_message, p_function, p_file, p_line);
+		internal::gdn_interface->print_error(p_message, p_function, p_file, p_line);
 	}
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -35,15 +35,15 @@
 namespace godot {
 
 void *Memory::alloc_static(size_t p_bytes) {
-	return internal::interface->mem_alloc(p_bytes);
+	return internal::gdn_interface->mem_alloc(p_bytes);
 }
 
 void *Memory::realloc_static(void *p_memory, size_t p_bytes) {
-	return internal::interface->mem_realloc(p_memory, p_bytes);
+	return internal::gdn_interface->mem_realloc(p_memory, p_bytes);
 }
 
 void Memory::free_static(void *p_ptr) {
-	internal::interface->mem_free(p_ptr);
+	internal::gdn_interface->mem_free(p_ptr);
 }
 
 } // namespace godot

--- a/src/core/method_bind.cpp
+++ b/src/core/method_bind.cpp
@@ -103,7 +103,7 @@ void MethodBind::bind_call(void *p_method_userdata, GDExtensionClassInstancePtr 
 	Variant ret = bind->call(p_instance, p_args, p_argument_count, *r_error);
 	// This assumes the return value is an empty Variant, so it doesn't need to call the destructor first.
 	// Since only NativeExtensionMethodBind calls this from the Godot side, it should always be the case.
-	internal::interface->variant_new_copy(r_return, ret.ptr());
+	internal::gdn_interface->variant_new_copy(r_return, ret.ptr());
 }
 
 void MethodBind::bind_ptrcall(void *p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_return) {

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -41,7 +41,7 @@ namespace godot {
 
 namespace internal {
 
-const GDNativeInterface *interface = nullptr;
+const GDNativeInterface *gdn_interface = nullptr;
 GDNativeExtensionClassLibraryPtr library = nullptr;
 void *token = nullptr;
 
@@ -51,7 +51,7 @@ GDExtensionBinding::Callback GDExtensionBinding::init_callbacks[GDNATIVE_MAX_INI
 GDExtensionBinding::Callback GDExtensionBinding::terminate_callbacks[GDNATIVE_MAX_INITIALIZATION_LEVEL] = {};
 
 GDNativeBool GDExtensionBinding::init(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization) {
-	internal::interface = p_interface;
+	internal::gdn_interface = p_interface;
 	internal::library = p_library;
 	internal::token = p_library;
 
@@ -143,7 +143,7 @@ void GDExtensionBinding::InitObject::register_driver_terminator(Callback p_drive
 }
 
 GDNativeBool GDExtensionBinding::InitObject::init() const {
-	return GDExtensionBinding::init(interface, library, initialization);
+	return GDExtensionBinding::init(gdn_interface, library, initialization);
 }
 
 } // namespace godot

--- a/src/variant/char_string.cpp
+++ b/src/variant/char_string.cpp
@@ -75,25 +75,25 @@ CharWideString::~CharWideString() {
 // It's easier to have them written in C++ directly than in a Python script that generates them.
 
 String::String(const char *from) {
-	internal::interface->string_new_with_utf8_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_utf8_chars(ptr(), from);
 }
 
 String::String(const wchar_t *from) {
-	internal::interface->string_new_with_wide_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_wide_chars(ptr(), from);
 }
 
 String::String(const char16_t *from) {
-	internal::interface->string_new_with_utf16_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_utf16_chars(ptr(), from);
 }
 
 String::String(const char32_t *from) {
-	internal::interface->string_new_with_utf32_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_utf32_chars(ptr(), from);
 }
 
 CharString String::utf8() const {
-	int size = internal::interface->string_to_utf8_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_utf8_chars(ptr(), nullptr, 0);
 	char *cstr = memnew_arr(char, size + 1);
-	internal::interface->string_to_utf8_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_utf8_chars(ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -101,9 +101,9 @@ CharString String::utf8() const {
 }
 
 CharString String::ascii() const {
-	int size = internal::interface->string_to_latin1_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_latin1_chars(ptr(), nullptr, 0);
 	char *cstr = memnew_arr(char, size + 1);
-	internal::interface->string_to_latin1_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_latin1_chars(ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -111,9 +111,9 @@ CharString String::ascii() const {
 }
 
 Char16String String::utf16() const {
-	int size = internal::interface->string_to_utf16_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_utf16_chars(ptr(), nullptr, 0);
 	char16_t *cstr = memnew_arr(char16_t, size + 1);
-	internal::interface->string_to_utf16_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_utf16_chars(ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -121,9 +121,9 @@ Char16String String::utf16() const {
 }
 
 Char32String String::utf32() const {
-	int size = internal::interface->string_to_utf32_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_utf32_chars(ptr(), nullptr, 0);
 	char32_t *cstr = memnew_arr(char32_t, size + 1);
-	internal::interface->string_to_utf32_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_utf32_chars(ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -131,9 +131,9 @@ Char32String String::utf32() const {
 }
 
 CharWideString String::wide_string() const {
-	int size = internal::interface->string_to_wide_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_wide_chars(ptr(), nullptr, 0);
 	wchar_t *cstr = memnew_arr(wchar_t, size + 1);
-	internal::interface->string_to_wide_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_wide_chars(ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -193,11 +193,11 @@ bool String::operator!=(const char32_t *p_str) const {
 }
 
 const char32_t &String::operator[](int p_index) const {
-	return *internal::interface->string_operator_index_const((GDNativeStringPtr)this, p_index);
+	return *internal::gdn_interface->string_operator_index_const((GDNativeStringPtr)this, p_index);
 }
 
 char32_t &String::operator[](int p_index) {
-	return *internal::interface->string_operator_index((GDNativeStringPtr)this, p_index);
+	return *internal::gdn_interface->string_operator_index((GDNativeStringPtr)this, p_index);
 }
 
 bool operator==(const char *p_chr, const String &p_str) {

--- a/src/variant/packed_arrays.cpp
+++ b/src/variant/packed_arrays.cpp
@@ -45,82 +45,82 @@
 namespace godot {
 
 const uint8_t &PackedByteArray::operator[](int p_index) const {
-	return *internal::interface->packed_byte_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_byte_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 uint8_t &PackedByteArray::operator[](int p_index) {
-	return *internal::interface->packed_byte_array_operator_index((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_byte_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
 const Color &PackedColorArray::operator[](int p_index) const {
-	const Color *color = (const Color *)internal::interface->packed_color_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	const Color *color = (const Color *)internal::gdn_interface->packed_color_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *color;
 }
 
 Color &PackedColorArray::operator[](int p_index) {
-	Color *color = (Color *)internal::interface->packed_color_array_operator_index((GDNativeTypePtr *)this, p_index);
+	Color *color = (Color *)internal::gdn_interface->packed_color_array_operator_index((GDNativeTypePtr *)this, p_index);
 	return *color;
 }
 
 const float &PackedFloat32Array::operator[](int p_index) const {
-	return *internal::interface->packed_float32_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_float32_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 float &PackedFloat32Array::operator[](int p_index) {
-	return *internal::interface->packed_float32_array_operator_index((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_float32_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
 const double &PackedFloat64Array::operator[](int p_index) const {
-	return *internal::interface->packed_float64_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_float64_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 double &PackedFloat64Array::operator[](int p_index) {
-	return *internal::interface->packed_float64_array_operator_index((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_float64_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
 const int32_t &PackedInt32Array::operator[](int p_index) const {
-	return *internal::interface->packed_int32_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_int32_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 int32_t &PackedInt32Array::operator[](int p_index) {
-	return *internal::interface->packed_int32_array_operator_index((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_int32_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
 const int64_t &PackedInt64Array::operator[](int p_index) const {
-	return *internal::interface->packed_int64_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_int64_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 int64_t &PackedInt64Array::operator[](int p_index) {
-	return *internal::interface->packed_int64_array_operator_index((GDNativeTypePtr *)this, p_index);
+	return *internal::gdn_interface->packed_int64_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
 const String &PackedStringArray::operator[](int p_index) const {
-	const String *string = (const String *)internal::interface->packed_string_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	const String *string = (const String *)internal::gdn_interface->packed_string_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *string;
 }
 
 String &PackedStringArray::operator[](int p_index) {
-	String *string = (String *)internal::interface->packed_string_array_operator_index((GDNativeTypePtr *)this, p_index);
+	String *string = (String *)internal::gdn_interface->packed_string_array_operator_index((GDNativeTypePtr *)this, p_index);
 	return *string;
 }
 
 const Vector2 &PackedVector2Array::operator[](int p_index) const {
-	const Vector2 *vec = (const Vector2 *)internal::interface->packed_vector2_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	const Vector2 *vec = (const Vector2 *)internal::gdn_interface->packed_vector2_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *vec;
 }
 
 Vector2 &PackedVector2Array::operator[](int p_index) {
-	Vector2 *vec = (Vector2 *)internal::interface->packed_vector2_array_operator_index((GDNativeTypePtr *)this, p_index);
+	Vector2 *vec = (Vector2 *)internal::gdn_interface->packed_vector2_array_operator_index((GDNativeTypePtr *)this, p_index);
 	return *vec;
 }
 
 const Vector3 &PackedVector3Array::operator[](int p_index) const {
-	const Vector3 *vec = (const Vector3 *)internal::interface->packed_vector3_array_operator_index_const((GDNativeTypePtr *)this, p_index);
+	const Vector3 *vec = (const Vector3 *)internal::gdn_interface->packed_vector3_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *vec;
 }
 
 Vector3 &PackedVector3Array::operator[](int p_index) {
-	Vector3 *vec = (Vector3 *)internal::interface->packed_vector3_array_operator_index((GDNativeTypePtr *)this, p_index);
+	Vector3 *vec = (Vector3 *)internal::gdn_interface->packed_vector3_array_operator_index((GDNativeTypePtr *)this, p_index);
 	return *vec;
 }
 

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -45,8 +45,8 @@ GDNativeTypeFromVariantConstructorFunc Variant::to_type_constructor[Variant::VAR
 void Variant::init_bindings() {
 	// Start from 1 to skip NIL.
 	for (int i = 1; i < VARIANT_MAX; i++) {
-		from_type_constructor[i] = internal::interface->get_variant_from_type_constructor((GDNativeVariantType)i);
-		to_type_constructor[i] = internal::interface->get_variant_to_type_constructor((GDNativeVariantType)i);
+		from_type_constructor[i] = internal::gdn_interface->get_variant_from_type_constructor((GDNativeVariantType)i);
+		to_type_constructor[i] = internal::gdn_interface->get_variant_to_type_constructor((GDNativeVariantType)i);
 	}
 
 	String::init_bindings();
@@ -69,15 +69,15 @@ void Variant::init_bindings() {
 }
 
 Variant::Variant() {
-	internal::interface->variant_new_nil(ptr());
+	internal::gdn_interface->variant_new_nil(ptr());
 }
 
 Variant::Variant(const GDNativeVariantPtr native_ptr) {
-	internal::interface->variant_new_copy(ptr(), native_ptr);
+	internal::gdn_interface->variant_new_copy(ptr(), native_ptr);
 }
 
 Variant::Variant(const Variant &other) {
-	internal::interface->variant_new_copy(ptr(), other.ptr());
+	internal::gdn_interface->variant_new_copy(ptr(), other.ptr());
 }
 
 Variant::Variant(Variant &&other) {
@@ -227,7 +227,7 @@ Variant::Variant(const PackedColorArray &v) {
 }
 
 Variant::~Variant() {
-	internal::interface->variant_destroy(ptr());
+	internal::gdn_interface->variant_destroy(ptr());
 }
 
 Variant::operator bool() const {
@@ -372,7 +372,7 @@ Variant::operator Object *() const {
 	if (obj == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<Object *>(internal::interface->object_get_instance_binding(obj, internal::token, &Object::___binding_callbacks));
+	return reinterpret_cast<Object *>(internal::gdn_interface->object_get_instance_binding(obj, internal::token, &Object::___binding_callbacks));
 }
 
 Variant::operator Callable() const {
@@ -455,7 +455,7 @@ Variant::operator PackedColorArray() const {
 
 Variant &Variant::operator=(const Variant &other) {
 	clear();
-	internal::interface->variant_new_copy(ptr(), other.ptr());
+	internal::gdn_interface->variant_new_copy(ptr(), other.ptr());
 	return *this;
 }
 
@@ -495,22 +495,22 @@ bool Variant::operator<(const Variant &other) const {
 }
 
 void Variant::call(const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDNativeCallError &r_error) {
-	internal::interface->variant_call(ptr(), method.ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret.ptr(), &r_error);
+	internal::gdn_interface->variant_call(ptr(), method.ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret.ptr(), &r_error);
 }
 
 void Variant::call_static(Variant::Type type, const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDNativeCallError &r_error) {
-	internal::interface->variant_call_static(static_cast<GDNativeVariantType>(type), method.ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret.ptr(), &r_error);
+	internal::gdn_interface->variant_call_static(static_cast<GDNativeVariantType>(type), method.ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret.ptr(), &r_error);
 }
 
 void Variant::evaluate(const Operator &op, const Variant &a, const Variant &b, Variant &r_ret, bool &r_valid) {
 	GDNativeBool valid;
-	internal::interface->variant_evaluate(static_cast<GDNativeVariantOperator>(op), a.ptr(), b.ptr(), r_ret.ptr(), &valid);
+	internal::gdn_interface->variant_evaluate(static_cast<GDNativeVariantOperator>(op), a.ptr(), b.ptr(), r_ret.ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 }
 
 void Variant::set(const Variant &key, const Variant &value, bool *r_valid) {
 	GDNativeBool valid;
-	internal::interface->variant_set(ptr(), key.ptr(), value.ptr(), &valid);
+	internal::gdn_interface->variant_set(ptr(), key.ptr(), value.ptr(), &valid);
 	if (r_valid) {
 		*r_valid = PtrToArg<bool>::convert(&valid);
 	}
@@ -518,27 +518,27 @@ void Variant::set(const Variant &key, const Variant &value, bool *r_valid) {
 
 void Variant::set_named(const StringName &name, const Variant &value, bool &r_valid) {
 	GDNativeBool valid;
-	internal::interface->variant_set_named(ptr(), name.ptr(), value.ptr(), &valid);
+	internal::gdn_interface->variant_set_named(ptr(), name.ptr(), value.ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 }
 
 void Variant::set_indexed(int64_t index, const Variant &value, bool &r_valid, bool &r_oob) {
 	GDNativeBool valid, oob;
-	internal::interface->variant_set_indexed(ptr(), index, value.ptr(), &valid, &oob);
+	internal::gdn_interface->variant_set_indexed(ptr(), index, value.ptr(), &valid, &oob);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	r_oob = PtrToArg<bool>::convert(&oob);
 }
 
 void Variant::set_keyed(const Variant &key, const Variant &value, bool &r_valid) {
 	GDNativeBool valid;
-	internal::interface->variant_set_keyed(ptr(), key.ptr(), value.ptr(), &valid);
+	internal::gdn_interface->variant_set_keyed(ptr(), key.ptr(), value.ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 }
 
 Variant Variant::get(const Variant &key, bool *r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::interface->variant_get(ptr(), key.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_get(ptr(), key.ptr(), result.ptr(), &valid);
 	if (r_valid) {
 		*r_valid = PtrToArg<bool>::convert(&valid);
 	}
@@ -548,7 +548,7 @@ Variant Variant::get(const Variant &key, bool *r_valid) const {
 Variant Variant::get_named(const StringName &name, bool &r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::interface->variant_get_named(ptr(), name.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_get_named(ptr(), name.ptr(), result.ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	return result;
 }
@@ -557,7 +557,7 @@ Variant Variant::get_indexed(int64_t index, bool &r_valid, bool &r_oob) const {
 	Variant result;
 	GDNativeBool valid;
 	GDNativeBool oob;
-	internal::interface->variant_get_indexed(ptr(), index, result.ptr(), &valid, &oob);
+	internal::gdn_interface->variant_get_indexed(ptr(), index, result.ptr(), &valid, &oob);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	r_oob = PtrToArg<bool>::convert(&oob);
 	return result;
@@ -566,7 +566,7 @@ Variant Variant::get_indexed(int64_t index, bool &r_valid, bool &r_oob) const {
 Variant Variant::get_keyed(const Variant &key, bool &r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::interface->variant_get_keyed(ptr(), key.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_get_keyed(ptr(), key.ptr(), result.ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	return result;
 }
@@ -583,36 +583,36 @@ bool Variant::in(const Variant &index, bool *r_valid) const {
 
 bool Variant::iter_init(Variant &r_iter, bool &r_valid) const {
 	GDNativeBool valid;
-	internal::interface->variant_iter_init(ptr(), r_iter.ptr(), &valid);
+	internal::gdn_interface->variant_iter_init(ptr(), r_iter.ptr(), &valid);
 	return PtrToArg<bool>::convert(&valid);
 }
 
 bool Variant::iter_next(Variant &r_iter, bool &r_valid) const {
 	GDNativeBool valid;
-	internal::interface->variant_iter_next(ptr(), r_iter.ptr(), &valid);
+	internal::gdn_interface->variant_iter_next(ptr(), r_iter.ptr(), &valid);
 	return PtrToArg<bool>::convert(&valid);
 }
 
 Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::interface->variant_iter_get(ptr(), r_iter.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_iter_get(ptr(), r_iter.ptr(), result.ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	return result;
 }
 
 Variant::Type Variant::get_type() const {
-	return static_cast<Variant::Type>(internal::interface->variant_get_type(ptr()));
+	return static_cast<Variant::Type>(internal::gdn_interface->variant_get_type(ptr()));
 }
 
 bool Variant::has_method(const StringName &method) const {
-	GDNativeBool has = internal::interface->variant_has_method(ptr(), method.ptr());
+	GDNativeBool has = internal::gdn_interface->variant_has_method(ptr(), method.ptr());
 	return PtrToArg<bool>::convert(&has);
 }
 
 bool Variant::has_key(const Variant &key, bool *r_valid) const {
 	GDNativeBool valid;
-	GDNativeBool has = internal::interface->variant_has_key(ptr(), key.ptr(), &valid);
+	GDNativeBool has = internal::gdn_interface->variant_has_key(ptr(), key.ptr(), &valid);
 	if (r_valid) {
 		*r_valid = PtrToArg<bool>::convert(&valid);
 	}
@@ -620,23 +620,23 @@ bool Variant::has_key(const Variant &key, bool *r_valid) const {
 }
 
 bool Variant::has_member(Variant::Type type, const StringName &member) {
-	GDNativeBool has = internal::interface->variant_has_member(static_cast<GDNativeVariantType>(type), member.ptr());
+	GDNativeBool has = internal::gdn_interface->variant_has_member(static_cast<GDNativeVariantType>(type), member.ptr());
 	return PtrToArg<bool>::convert(&has);
 }
 
 bool Variant::hash_compare(const Variant &variant) const {
-	GDNativeBool compare = internal::interface->variant_hash_compare(ptr(), variant.ptr());
+	GDNativeBool compare = internal::gdn_interface->variant_hash_compare(ptr(), variant.ptr());
 	return PtrToArg<bool>::convert(&compare);
 }
 
 bool Variant::booleanize() const {
-	GDNativeBool booleanized = internal::interface->variant_booleanize(ptr());
+	GDNativeBool booleanized = internal::gdn_interface->variant_booleanize(ptr());
 	return PtrToArg<bool>::convert(&booleanized);
 }
 
 String Variant::stringify() const {
 	String result;
-	internal::interface->variant_stringify(ptr(), result.ptr());
+	internal::gdn_interface->variant_stringify(ptr(), result.ptr());
 	return result;
 }
 
@@ -644,33 +644,33 @@ Variant Variant::duplicate(bool deep) const {
 	Variant result;
 	GDNativeBool _deep;
 	PtrToArg<bool>::encode(deep, &_deep);
-	internal::interface->variant_duplicate(ptr(), result.ptr(), _deep);
+	internal::gdn_interface->variant_duplicate(ptr(), result.ptr(), _deep);
 	return result;
 }
 
 void Variant::blend(const Variant &a, const Variant &b, float c, Variant &r_dst) {
-	internal::interface->variant_blend(a.ptr(), b.ptr(), c, r_dst.ptr());
+	internal::gdn_interface->variant_blend(a.ptr(), b.ptr(), c, r_dst.ptr());
 }
 
 void Variant::interpolate(const Variant &a, const Variant &b, float c, Variant &r_dst) {
-	internal::interface->variant_interpolate(a.ptr(), b.ptr(), c, r_dst.ptr());
+	internal::gdn_interface->variant_interpolate(a.ptr(), b.ptr(), c, r_dst.ptr());
 }
 
 String Variant::get_type_name(Variant::Type type) {
 	String result;
-	internal::interface->variant_get_type_name(static_cast<GDNativeVariantType>(type), result.ptr());
+	internal::gdn_interface->variant_get_type_name(static_cast<GDNativeVariantType>(type), result.ptr());
 	return result;
 }
 
 bool Variant::can_convert(Variant::Type from, Variant::Type to) {
 	GDNativeBool can;
-	internal::interface->variant_can_convert(static_cast<GDNativeVariantType>(from), static_cast<GDNativeVariantType>(to));
+	internal::gdn_interface->variant_can_convert(static_cast<GDNativeVariantType>(from), static_cast<GDNativeVariantType>(to));
 	return PtrToArg<bool>::convert(&can);
 }
 
 bool Variant::can_convert_strict(Variant::Type from, Variant::Type to) {
 	GDNativeBool can;
-	internal::interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(from), static_cast<GDNativeVariantType>(to));
+	internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(from), static_cast<GDNativeVariantType>(to));
 	return PtrToArg<bool>::convert(&can);
 }
 
@@ -718,9 +718,9 @@ void Variant::clear() {
 	};
 
 	if (unlikely(needs_deinit[get_type()])) { // Make it fast for types that don't need deinit.
-		internal::interface->variant_destroy(ptr());
+		internal::gdn_interface->variant_destroy(ptr());
 	}
-	internal::interface->variant_new_nil(ptr());
+	internal::gdn_interface->variant_new_nil(ptr());
 }
 
 } // namespace godot

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -31,6 +31,12 @@
 #ifndef EXAMPLE_CLASS_H
 #define EXAMPLE_CLASS_H
 
+// We don't need windows.h in this plugin but many others do and it throws up on itself all the time
+// So best to include it and make sure CI warns us when we use something Microsoft took for their own goals....
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/classes/viewport.hpp>


### PR DESCRIPTION
For plugins authored for Windows, especially those that need to call into system APIs, we need to include `windows.h` which is always fun and games as Microsoft has a habit of redefining stuff to their needs.

One of those redefines is `#define interface __STRUCT__` which is causing havoc to our code base.
We can't undefine this, the redefine is part of Microsofts COM system which is a prime candidate to have plugins build against.

We use `interface` as the variable name to store our interface pointer into Godot. This PR simply renames it to `gdn_interface`.

I've also added an include of `windows.h` into our test project so we capture similar issues early through CI. 