### PR TITLE
[3.x] Unify bits, macos_arch into arch, support non-x86 on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: 🐧 Linux (GCC)
+          - name: 🐧 Linux (x86_64, GCC)
             os: ubuntu-22.04
             platform: linux
             artifact-name: godot-cpp-linux-glibc2.35-x86_64-release
-            artifact-path: bin/libgodot-cpp.linux.release.64.a
+            artifact-path: bin/libgodot-cpp.linux.release.x86_64.a
             godot_zip: Godot_v3.6-stable_linux_server.64.zip
             executable: Godot_v3.6-stable_linux_server.64
             cache-name: linux-x86_64
@@ -30,14 +30,14 @@ jobs:
             os: windows-2022
             platform: windows
             artifact-name: godot-cpp-windows-msvc2022-x86_64-release
-            artifact-path: bin/libgodot-cpp.windows.release.64.lib
+            artifact-path: bin/libgodot-cpp.windows.release.x86_64.lib
             cache-name: windows-x86_64-msvc
 
           - name: 🏁 Windows (x86_64, MinGW)
             os: windows-2022
             platform: windows
             artifact-name: godot-cpp-linux-mingw-x86_64-release
-            artifact-path: bin/libgodot-cpp.windows.release.64.a
+            artifact-path: bin/libgodot-cpp.windows.release.x86_64.a
             flags: use_mingw=yes
             cache-name: windows-x86_64-mingw
 
@@ -45,7 +45,7 @@ jobs:
             os: macos-15
             platform: osx
             artifact-name: godot-cpp-macos-universal-release
-            artifact-path: bin/libgodot-cpp.osx.release.64.a
+            artifact-path: bin/libgodot-cpp.osx.release.universal.a
             flags: macos_arch=universal
             godot_zip: Godot_v3.6-stable_osx.universal.zip
             executable: Godot.app/Contents/MacOS/Godot

--- a/test/gdexample.gdnlib
+++ b/test/gdexample.gdnlib
@@ -7,10 +7,10 @@ reloadable=false
 
 [entry]
 
-X11.64="res://bin/libgdexample.linux.release.64.so"
-Server.64="res://bin/libgdexample.linux.release.64.so"
-Windows.64="res://bin/libgdexample.windows.release.64.dll"
-OSX.64="res://bin/libgdexample.osx.release.64.dylib"
+X11.64="res://bin/libgdexample.linux.release.x86_64.so"
+Server.64="res://bin/libgdexample.linux.release.x86_64.so"
+Windows.64="res://bin/libgdexample.windows.release.x86_64.dll"
+OSX.64="res://bin/libgdexample.osx.release.universal.dylib"
 
 [dependencies]
 


### PR DESCRIPTION
This PR unifies arguments for bits and macos_arch, replacing them with one "arch" argument. This simplifies the code and adds support for ARM64 and RV64 Linux (PPC64 may or may not work, completely untested).

I did not change the behavior for Android and iOS to avoid unintentional breakage, but for other platforms this does intentionally break compatibility with the files produced by the build system, so users will need to adjust their `.gdnlib` files (or just not upgrade to the godot-cpp commit that includes this PR).

On Windows and Linux, either `bits` or `arch` can be used to specify the architecture. `bits=32` is treated the same as `arch=x86_32` and `bits=64` is treated the same as `arch=x86_64`. On macOS, `bits` does nothing, and either `arch` or `macos_arch` can be used to specify the architecture (defaults to universal, can also be set to x86_64 or arm64).

I tested compiling x86_64 Windows, universal/x86_64/arm64 macOS, x86_32/x86_64/arm64/rv64 Ubuntu Linux, and the web platform (the suffix changes from wasm to wasm32).

Old PR description (previously it modified Android and iOS too and removed the old build options):

<details>

This PR unifies arguments for bits, android_arch, macos_arch, and ios_arch, replacing them all with one "arch" argument. This simplifies the code and adds support for ARM64 and RV64 Linux (PPC64 may or may not work, completely untested).

This breaks build system compatibility, since now those arguments do nothing, and you need to write "arch=" instead to specify the architecture. However, most users will not need to do this anyway since it will default to a good choice (universal for macOS, arm64 for Android and iOS, wasm32 on web, otherwise host arch). Also, this breaks compatibility with the final library name, so users will need to minorly adjust their projects.

To test it, here is a version built on the 3.4 branch: https://github.com/aaronfranke/godot-cpp/tree/3.4-scons-cpu-arch

And here is a branch of the demos using that 3.4 branch: https://github.com/aaronfranke/gdnative-demos/tree/scons-cpu-arch

I tested the demos using the 3.4 version on x86_64 Windows, universal/x86_64/arm64 macOS, x86_32/x86_64/arm64/rv64 Ubuntu Linux, and I tested compiling without running with arm64/x86_64 Android and arm32/arm64 iOS. I wasn't able to get the JavaScript platform working either with or without these changes. Overall, this PR tries to not overhaul the SConstruct file too much and just improves the architecture handling, so hopefully what was working will keep working.

This PR also updates the headers to the 3.x branch of the headers repo, updates the CI to use 3.5 beta1, and updates the test project SConstruct to be a copy of the SConstruct files in the gdnative-demos repository.