### PR TITLE
Fix CMake files and add build flag to toggle between static/dynamic MSVC runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,10 @@ jobs:
 
       - name: Build godot-cpp
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 16 2019" .
-          cmake --build . --verbose
+          cmake -G"Visual Studio 16 2019" .
+          cmake --build . --config Release --verbose
 
       - name: Build test GDNative library
         run: |
-          cd test && cmake -DCMAKE_BUILD_TYPE=Release -DGODOT_HEADERS_PATH="../godot-headers" -DCPP_BINDINGS_PATH=".." -G"Visual Studio 16 2019" .
-          cmake --build . --verbose
+          cd test && cmake -DGODOT_HEADERS_PATH="../godot-headers" -DCPP_BINDINGS_PATH=".." -G"Visual Studio 16 2019" .
+          cmake --build . --config Release --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,14 @@
 # Todo
 # Test build for Windows, Mac and mingw.
 
+cmake_minimum_required(VERSION 3.15)
+
 project(godot-cpp LANGUAGES CXX)
-cmake_minimum_required(VERSION 3.6)
+
+include(CMakeDependentOption)
 
 option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)
+cmake_dependent_option(USE_STATIC_RUNTIME_LIBRARY "Link C++ runtime libraries statically" OFF "MSVC" ON)
 
 set(BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${BUILD_PATH}")
@@ -50,11 +54,6 @@ SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${BUILD_PATH}")
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${BUILD_PATH}")
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG "${BUILD_PATH}")
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${BUILD_PATH}")
-
-# Default build type is Debug in the SConstruct
-if("${CMAKE_BUILD_TYPE}" STREQUAL "")
-	set(CMAKE_BUILD_TYPE Debug)
-endif()
 
 # Set the c++ standard to c++17
 set(CMAKE_CXX_STANDARD 17)
@@ -82,26 +81,12 @@ set(GODOT_LINKER_FLAGS )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# using Visual Studio C++
-	set(GODOT_COMPILE_FLAGS "/EHsc /WX") # /GF /MP
-
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MDd") # /Od /RTC1 /Zi
-	else()
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MD /O2") # /Oy /GL /Gy
-		STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-		string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-	endif(CMAKE_BUILD_TYPE MATCHES Debug)
+	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /W3 /WX")
 
 	# Disable conversion warning, truncation, unreferenced var, signed mismatch, different type
 	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /wd4244 /wd4305 /wd4101 /wd4018 /wd4267 /wd4099")
 
 	add_definitions(-DNOMINMAX)
-
-	# Unkomment for warning level 4
-	#if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-	#	string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-	#endif()
-
 else()  # GCC/Clang
 	set(GODOT_LINKER_FLAGS "-static-libgcc -static-libstdc++ -Wl,-R,'$$ORIGIN'")
 
@@ -125,12 +110,6 @@ else()  # GCC/Clang
 	if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -Wno-ignored-attributes")
 	endif()
-
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -fno-omit-frame-pointer -O0")
-	else()
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -O3")
-	endif(CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 # Generate source from the bindings file
@@ -190,11 +169,17 @@ target_include_directories(${PROJECT_NAME}
 set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
 set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
 
+# Set the desired runtime linkage for MSVC (/MT[d] or /MD[d])
+if(USE_STATIC_RUNTIME_LIBRARY)
+	set_property(TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else()
+	set_property(TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
 
-# Create the correct name (godot.os.build_type.system_bits)
+# Create the correct name (godot-cpp.os[.android_abi].build_type[.system_bits])
 
-string(TOLOWER "${CMAKE_SYSTEM_NAME}" SYSTEM_NAME)
-string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
+set(SYSTEM_NAME "$<LOWER_CASE:$<PLATFORM_ID>>")
+set(BUILD_TYPE "$<LOWER_CASE:$<CONFIG>>")
 
 if(ANDROID)
 	# Added the android abi after system name

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
+cmake_minimum_required(VERSION 3.15)
+
 project(godot-cpp-test)
-cmake_minimum_required(VERSION 3.6)
 
 set(GODOT_HEADERS_PATH ../godot-headers/ CACHE STRING "Path to Godot headers")
 set(CPP_BINDINGS_PATH ../ CACHE STRING "Path to C++ bindings")
@@ -36,27 +37,13 @@ set(GODOT_LINKER_FLAGS )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# using Visual Studio C++
-	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /EHsc /WX") # /GF /MP
+	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /W3 /WX")
 	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /DTYPED_METHOD_BIND")
-
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MDd") # /Od /RTC1 /Zi
-	else()
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MD /O2") # /Oy /GL /Gy
-		STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-		string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-	endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 	# Disable conversion warning, truncation, unreferenced var, signed mismatch
 	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /wd4244 /wd4305 /wd4101 /wd4018 /wd4267")
 
 	add_definitions(-DNOMINMAX)
-
-	# Unkomment for warning level 4
-	#if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-	#	string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-	#endif()
-
 else()
 
 #elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -84,12 +71,6 @@ else()
 	if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -Wno-ignored-attributes")
 	endif()
-
-	if(CMAKE_BUILD_TYPE MATCHES Debug)
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -fno-omit-frame-pointer -O0")
-	else()
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -O3")
-	endif(CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 # Get Sources
@@ -114,34 +95,22 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	set(BITS 64)
 endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-	set(GODOT_CPP_BUILD_TYPE Debug)
-else()
-	set(GODOT_CPP_BUILD_TYPE Release)
-endif()
-
-string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME)
-string(TOLOWER ${GODOT_CPP_BUILD_TYPE} BUILD_TYPE)
+set(SYSTEM_NAME "$<LOWER_CASE:$<PLATFORM_ID>>")
+set(BUILD_TYPE "$<LOWER_CASE:$<CONFIG>>")
 
 if(ANDROID)
 	# Added the android abi after system name
 	set(SYSTEM_NAME ${SYSTEM_NAME}.${ANDROID_ABI})
 endif()
 
-if(CMAKE_VERSION VERSION_GREATER "3.13")
-	target_link_directories(${PROJECT_NAME}
-		PRIVATE
-		${CPP_BINDINGS_PATH}/bin/
-	)
+target_link_directories(${PROJECT_NAME}
+	PRIVATE
+	${CPP_BINDINGS_PATH}/bin/
+)
 
-	target_link_libraries(${PROJECT_NAME}
-		godot-cpp.${SYSTEM_NAME}.${BUILD_TYPE}$<$<NOT:$<PLATFORM_ID:Android>>:.${BITS}>
-	)
-else()
-	target_link_libraries(${PROJECT_NAME}
-			${CPP_BINDINGS_PATH}/bin/libgodot-cpp.${SYSTEM_NAME}.${BUILD_TYPE}$<$<NOT:$<PLATFORM_ID:Android>>:.${BITS}>.a
-	)
-endif()
+target_link_libraries(${PROJECT_NAME}
+	godot-cpp.${SYSTEM_NAME}.${BUILD_TYPE}$<$<NOT:$<PLATFORM_ID:Android>>:.${BITS}>
+)
 
 # Add the compile flags
 set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -9,6 +9,9 @@ from SCons.Variables import *
 def options(opts):
     opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_clang_cl", "Use the clang driver instead of MSVC - only effective on Windows", False))
+    opts.Add(
+        BoolVariable("use_static_cpp", "Link MSVC C++ runtime libraries statically - only effective on Windows", False)
+    )
 
 
 def exists(env):
@@ -27,10 +30,10 @@ def generate(env):
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND", "NOMINMAX"])
         env.Append(CCFLAGS=["/EHsc"])
         env.Append(LINKFLAGS=["/WX"])
-        if env["debug_symbols"] or env["target"] == "debug":
-            env.Append(CCFLAGS=["/MDd"])
+        if env["dev_build"]:
+            env.Append(CCFLAGS=["/MTd" if env["use_static_cpp"] else "/MDd"])
         else:
-            env.Append(CCFLAGS=["/MD"])
+            env.Append(CCFLAGS=["/MT" if env["use_static_cpp"] else "/MD"])
 
         if env["use_clang_cl"]:
             env["CC"] = "clang-cl"


### PR DESCRIPTION
EDIT: See comments below for information regarding the "Fix CMake files" part.

This PR adds SCons and CMake build flags (`use_static_cpp` and `USE_STATIC_RUNTIME_LIBRARY` respectively) to change the linkage of MSVC runtime libraries, similar to [what's in the editor already](https://github.com/godotengine/godot/blob/99bc4905cbdeec4f91673aaf501703e28180c9d9/platform/windows/detect.py#L189).

Previously it was impossible to have your extension statically link the MSVC runtime library since godot-cpp was hardcoded to link the dynamic one, and mixing the two is not possible within the same binary.

The previous hardcoded value in the SCons file was also broken, as it was relying on the old target names (`"debug"`) to determine whether to use the debug runtime or not.

I also took the opportunity to bump the (in my opinion) overly conservative minimum required version for CMake. This allows use of the [`MSVC_RUNTIME_LIBRARY`](https://cmake.org/cmake/help/v3.15/prop_tgt/MSVC_RUNTIME_LIBRARY.html) target variable instead of having to hack it by string-replacing global compiler options. Previously this version was set to 3.6 (from July 2016) and is now instead 3.15 (from July 2019). Even something as conservative as Debian Stable includes CMake 3.18 (from July 2020).