### PR TITLE
Correctly load gdextension_interface_print_error

### DIFF
--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -235,7 +235,7 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 	LOAD_PROC_ADDRESS(mem_alloc, GDExtensionInterfaceMemAlloc);
 	LOAD_PROC_ADDRESS(mem_realloc, GDExtensionInterfaceMemRealloc);
 	LOAD_PROC_ADDRESS(mem_free, GDExtensionInterfaceMemFree);
-	LOAD_PROC_ADDRESS(print_error_with_message, GDExtensionInterfacePrintErrorWithMessage);
+	LOAD_PROC_ADDRESS(print_error, GDExtensionInterfacePrintError);
 	LOAD_PROC_ADDRESS(print_warning, GDExtensionInterfacePrintWarning);
 	LOAD_PROC_ADDRESS(print_warning_with_message, GDExtensionInterfacePrintWarningWithMessage);
 	LOAD_PROC_ADDRESS(print_script_error, GDExtensionInterfacePrintScriptError);


### PR DESCRIPTION
Fixes #1125

This looks like my mistake. Earlier in this function it's manually loading `gdextension_interface_print_error_with_message`, and so wouldn't need to load it again here. However, it appears I accidentally deleted the loading of `gdextension_interface_print_error`, rather than the 2nd loading of `gdextension_interface_print_error_with_message` that I had intended to delete.