### PR TITLE
Add `is_class_static` virtual method to GDCLASS macro.

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -98,6 +98,10 @@ public:
 		return string_name;
 	}
 
+	virtual bool is_class_static(const StringName &p_string_name) const {
+		return p_string_name == get_class_static();
+	}
+
 	uint64_t get_instance_id() const {
 		return 0;
 	}
@@ -220,6 +224,10 @@ public:                                                                         
 	static ::godot::StringName &get_class_static() {                                                                                                                                   \
 		static ::godot::StringName string_name = ::godot::StringName(#m_class);                                                                                                        \
 		return string_name;                                                                                                                                                            \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	virtual bool is_class_static(const StringName &p_string_name) const override {                                                                                                     \
+		return get_class_static() == p_string_name;                                                                                                                                    \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static ::godot::StringName &get_parent_class_static() {                                                                                                                            \


### PR DESCRIPTION
Link to proposal: https://github.com/godotengine/godot-proposals/issues/8852

In the `godot-cpp`, we already have `get_class_static()` added by `GDCLASS` macro. Having also an instance method `virtual bool is_class_static(StringName cn)` would provide an efficient comparison method to the already existing functionality.

### Usage
```cpp
Ref<MyBaseclass> ref = get_my_class(); // returns Ref<MySubclass>;
if (ref->is_class_static(MySubclass::get_class_static()) {
  // ...
}
```