### PR TITLE
Make build system more friendly when it's no longer top-level

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -21,16 +21,15 @@ env.PrependENVPath("PATH", os.getenv("PATH"))
 
 # Custom options and profile flags.
 customs = ["custom.py"]
-try:
-    customs += Import("customs")
-except:
-    pass
 profile = ARGUMENTS.get("profile", "")
 if profile:
-    if os.path.isfile(profile):
-        customs.append(profile)
-    elif os.path.isfile(profile + ".py"):
-        customs.append(profile + ".py")
+    if not profile.endswith('.py'):
+        profile += '.py'
+
+    path = str(Entry('#' + profile))
+
+    if (os.path.isfile(path)):
+        customs.append(path)
 opts = Variables(customs, ARGUMENTS)
 cpp_tool = Tool("godotcpp", toolpath=["tools"])
 cpp_tool.options(opts, env)
@@ -39,11 +38,13 @@ opts.Update(env)
 Help(opts.GenerateHelpText(env))
 
 # Detect and print a warning listing unknown SCons variables to ease troubleshooting.
-unknown = opts.UnknownVariables()
-if unknown:
-    print("WARNING: Unknown SCons variables were passed and will be ignored:")
-    for item in unknown.items():
-        print("    " + item[0] + "=" + item[1])
+# But only do that if this is top level SConstruct, not subsidiary
+if Dir("#").abspath == Dir(".").abspath:
+    unknown = opts.UnknownVariables()
+    if unknown:
+        print("WARNING: Unknown SCons variables were passed and will be ignored:")
+        for item in unknown.items():
+            print("    " + item[0] + "=" + item[1])
 
 scons_cache_path = os.environ.get("SCONS_CACHE")
 if scons_cache_path is not None:

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -198,6 +198,15 @@ def options(opts, env):
         )
     )
 
+    opts.Add(
+        PathVariable(
+            key="profile",
+            help="Allow specification of customization file other than `custom.py`.",
+            default=env.get("profile", None),
+            validator=validate_file,
+        )
+    )
+
     # Add platform options
     for pl in platforms:
         tool = Tool(pl, toolpath=["tools"])


### PR DESCRIPTION
This PR aims to address #1334 at least partially. With the changes:

- When the `profile=some_file.py` is given as argument, that file can be placed alongside the extension *SConstruct* directory rather than within the godot-cpp. Without the changed script, in order to keep the `some_file.py` with the extension then the argument must be changed to `profile=../some_file.py` (in other words, the path would have to be relative to godot-cpp *SConstruct*)
- Some lines that don't do anything were removed.
- Warning message of unknown *SCons* arguments are given only when godot-cpp *SConstruct* is running as top level script. If an extension author wishes to output that kind of warning it must be done within extension *SConstruct*, which becomes top-level.

A side note here. I kept the original `profile=...` logic of accepting file name without `.py` extension. However I have noticed that when this is the case, *SCons* generate a binary file with the exact same name of the profile file, but without any extension. As an example, if there is a `release.py` and the argument is given as `profile=release`, then a `release` file will be created. I was unable to track down what/where this thing happens.