### PR TITLE
Catch up with minor changes to `gdextension_interface.h`

### DIFF
--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -2384,6 +2384,9 @@ typedef void (*GDExtensionInterfaceObjectSetInstance)(GDExtensionObjectPtr p_o, 
  *
  * Gets the class name of an Object.
  *
+ * If the GDExtension wraps the Godot object in an abstraction specific to its class, this is the
+ * function that should be used to determine which wrapper to use.
+ *
  * @param p_object A pointer to the Object.
  * @param p_library A pointer the library received by the GDExtension's entry point function.
  * @param r_class_name A pointer to a String to receive the class name.
@@ -2658,7 +2661,7 @@ typedef void *(*GDExtensionInterfaceClassdbGetClassTag)(GDExtensionConstStringNa
 /**
  * @name classdb_register_extension_class
  * @since 4.1
- * @deprecated in Godot 4.2. Use `classdb_register_extension_class2` instead.
+ * @deprecated in Godot 4.2. Use `classdb_register_extension_class3` instead.
  *
  * Registers an extension class in the ClassDB.
  *
@@ -2674,6 +2677,7 @@ typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass)(GDExtensionCla
 /**
  * @name classdb_register_extension_class2
  * @since 4.2
+ * @deprecated in Godot 4.3. Use `classdb_register_extension_class3` instead.
  *
  * Registers an extension class in the ClassDB.
  *


### PR DESCRIPTION
We tend to merge changes to `gdextension_interface.h` piecemeal as we add support for each new feature that is added to it.

However, in that process, we seem to have missed some minor changes that are in the version in Godot `master`. They could have been corrections that came later, or a case where we forgot to update the godot-cpp PR as the Godot PR received changes.

This PR just copies the latest `gdextension_interface.h` from Godot master!