### PR TITLE
Add scons with_x86_64h option on macOS

### DIFF
--- a/tools/macos.py
+++ b/tools/macos.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import common_compiler_flags
+from SCons.Variables import BoolVariable
 
 
 def has_osxcross():
@@ -11,6 +12,7 @@ def has_osxcross():
 def options(opts):
     opts.Add("macos_deployment_target", "macOS deployment target", "default")
     opts.Add("macos_sdk_path", "macOS SDK path", "")
+    opts.Add(BoolVariable("with_x86_64h", "If arch=x86_64 or universal, include an x86_64h slice.", False))
     if has_osxcross():
         opts.Add("osxcross_sdk", "OSXCross SDK version", "darwin16")
 
@@ -54,6 +56,10 @@ def generate(env):
     else:
         env.Append(LINKFLAGS=["-arch", env["arch"]])
         env.Append(CCFLAGS=["-arch", env["arch"]])
+
+    if env["with_x86_64h"] and env["arch"] in ["universal", "x86_64"]:
+        env.Append(LINKFLAGS=["-arch", "x86_64h"])
+        env.Append(CCFLAGS=["-arch", "x86_64h"])
 
     if env["macos_deployment_target"] != "default":
         env.Append(CCFLAGS=["-mmacosx-version-min=" + env["macos_deployment_target"]])


### PR DESCRIPTION
This adds an x86_64h slice, which can lead to improved performance (at the cost of binary size).
It will be selected automatically on all post-2013 macs, if compiled. Pre 2013 macs will use the current x86_64 slice.

See https://github.com/godotengine/godot-proposals/issues/11150 for details about this feature.

The x86_64h slice is compiled alongside the x86_64 slice and is fully and transparently compatible with x86_64 godot. Therefore, we don't need to wait for any progress on the godot front to add this feature.

```
❯ scons arch=x86_64 dev_build=yes with_x86_64h=yes
...

❯ lipo -info project/bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug
Architectures in the fat file: project/bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug are: x86_64 x86_64h

godot-cpp/test x86_64h-slice-option ≡
❯ GODOT=/Applications/Godot4.4-dev4.app/Contents/MacOS/Godot  ./run-tests.sh
Godot Engine v4.4.dev4.official.36e6207bb - https://godotengine.org


 ==== TESTS FINISHED ====

   PASSES: 124
   FAILURES: 0

 ******** PASSED ********

grep: repetition-operator operand invalid
```

Removing the slice to see if x86_64h can be selected:

```
godot-cpp/test x86_64h-slice-option ≡
❯ lipo -remove x86_64 project/bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug -output project/bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug

❯ lipo -info project/bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug
Architectures in the fat file: project/bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug are: x86_64h

godot-cpp/test x86_64h-slice-option ≡
❯ GODOT=/Applications/Godot4.4-dev4.app/Contents/MacOS/Godot  ./run-tests.sh
Godot Engine v4.4.dev4.official.36e6207bb - https://godotengine.org


 ==== TESTS FINISHED ====

   PASSES: 124
   FAILURES: 0

 ******** PASSED ********

grep: repetition-operator operand invalid

godot-cpp/test x86_64h-slice-option ≡
```