### PR TITLE
Remove `.dev` suffix from builds.

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -296,7 +296,6 @@ function( godotcpp_generate )
         string( CONCAT GODOT_SUFFIX
                 "$<1:.${SYSTEM_NAME}>"
                 "$<1:.${TARGET_ALIAS}>"
-                "$<${IS_DEV_BUILD}:.dev>"
                 "$<$<STREQUAL:${GODOT_PRECISION},double>:.double>"
                 "$<1:.${ARCH_NAME}>"
                 # TODO IOS_SIMULATOR

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -526,6 +526,17 @@ void GDExtensionBinding::initialize_level(void *p_userdata, GDExtensionInitializ
 			doc_data.load_data();
 		}
 	}
+
+#ifdef DEV_ENABLED
+	if ((ModuleInitializationLevel)p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		callable_mp_static(+[]() {
+			String library_path;
+			internal::gdextension_interface_get_library_path(internal::library, library_path._native_ptr());
+
+			WARN_PRINT("GDExtension loaded from a development build: " + library_path);
+		}).call_deferred();
+	}
+#endif
 }
 
 void GDExtensionBinding::deinitialize_level(void *p_userdata, GDExtensionInitializationLevel p_level) {

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -485,8 +485,6 @@ def generate(env):
 
     # Suffix
     suffix = ".{}.{}".format(env["platform"], env["target"])
-    if env.dev_build:
-        suffix += ".dev"
     if env["precision"] == "double":
         suffix += ".double"
     suffix += "." + env["arch"]
@@ -496,7 +494,7 @@ def generate(env):
         suffix += ".nothreads"
 
     env["suffix"] = suffix  # Exposed when included from another project
-    env["OBJSUFFIX"] = suffix + env["OBJSUFFIX"]
+    env["OBJSUFFIX"] = suffix + (".dev" if env.dev_build else "") + env["OBJSUFFIX"]
 
     # compile_commands.json
     env.Tool("compilation_db")


### PR DESCRIPTION
I know this is going to be controversial, but it's a simple PR, so I want to just put it out there. I'm not 100% we should merge this, myself.

I have pre-written some thoughts _against_ this change below, and my thoughts for them.
They are a bit ramble-y, so feel free to partake in the discussion freely without acknowledging them 😅

## Reasoning

Currently, godot-cpp automatically adds the `.dev` suffix to builds that are created with the `dev_build=yes` flag.
This can result in binaries named like so:
```ini
libgdexample.linux.template_release.dev.x86_32.so  ; For dev_build=yes
libgdexample.linux.template_release.x86_32.so  ; For dev_build=no (default)
```

The `.gdextension` file needs to choose one of these formats to load from:
```ini
linux.release.x86_32 = "res://bin/libgdexample.linux.template_release.x86_32.so"
; Or:
linux.release.x86_32 = "res://bin/libgdexample.linux.template_release.dev.x86_32.so"
```

It cannot choose 'either': One of the two must be chosen. 

In a normal dev cycle, one may default to building with `dev_build=yes` to get faster builds for testing. Therefore, one may choose the `.dev` entry for the `demo` project.
However, when it comes to testing the project's release-ready binary, one must either test it in a different project, or edit the `.gdextension` file to load the non- `.dev` binary temporarily, or rename the binary to `.dev` by hand.

This is not only tedious, but actually confusing: I've seen a few people in Discord help channels run into problems because they built the version that _wasn't_ loaded by the editor, and wondered why the GDExtension wouldn't respond to code changes. I have also run into this problem, and proceeded to [strip `.dev` from my own dev versions in [`SConstruct`](https://github.com/Ivorforce/NumDot/blob/main/SConstruct#L98).

## In defense of `.dev`

**`.dev` is used for `.dev` binaries by Godot itself.** godot-cpp tries to emulate godot upstream behavior as much as possible, to reduce complexity across the projects. However, Godot does not have the problems described above, as the binary is not added to a `.gdextension` file. I think it makes sense for Godot, but less for godot-cpp.

**`.dev` denotes a compatibility change, like the other suffixes.** `.dev` includes debug symbols, and can therefore do things regular builds cannot. However, this does not concern Godot itself. For godot, it does not matter whether the binary is built with debug symbols or not. Therefore, I do not think this argument holds.

**`.dev` protects against confusing it for an optimized build.** dev builds are unoptimized, so uploading one would be a mistake. `.dev` suffixes protect against accidentally uploading the wrong version. I don't have any contra for this argument, it should be weighed against benefits. We could add other protections too, such as a warning when `dev` libraries are loaded into `Godot`.

**`.dev` can still be optimized, using explicit build args.** If one builds with `scons dev_build=yes lto=auto optimize=speed`, the resulting binary will be optimized very similar to an actual build. This may be good enough for testing performance. This is a valid workflow, and if we reject this PR, it should be documented.

**Compiling dev builds with `.dev` saves time when switching between the two.** This is correct, and arguably, we should keep `.dev` suffixes for object files to preserve this. However, preserving the final binary saves at most the LTO step, I think.

## Alternative Solution

Instead of stripping the `.dev` suffix, it would be possible to auto-generate a `.gdextension` file with a `SCons` tool. The entry would _always_ load the latest build in Godot, no matter the configuration. This would allow the binaries to keep their current name, and the above confusion to still be resolved. 
However, this would require making the tool, and `.gdextension` files would not be written by hand anymore. Instead, the tool would need to cover its whole range of features.

It is also possible for users that want to adopt this workflow to just strip `.dev` suffixes from the binary [like I did](https://github.com/Ivorforce/NumDot/blob/main/SConstruct#L98). This could be documented to give users freedom of choice.