### PR TITLE
Add `PRINT_VERBOSE` macro alongside the function

### DIFF
--- a/include/godot_cpp/core/print_string.hpp
+++ b/include/godot_cpp/core/print_string.hpp
@@ -67,4 +67,12 @@ void print_verbose(const Variant &p_variant, Args... p_args) {
 
 bool is_print_verbose_enabled();
 
+// This version avoids processing the text to be printed until it actually has to be printed, saving some CPU usage.
+#define PRINT_VERBOSE(m_variant) \
+	{ \
+		if (is_print_verbose_enabled()) { \
+			print_line(m_variant); \
+		} \
+	}
+
 } // namespace godot


### PR DESCRIPTION
In the Godot core team meeting on 2025-05-07, it was discussed that PR https://github.com/godotengine/godot/pull/100224 is a massive codebase-wide change that will conflict with many PRs and break compatibility with third-party modules. Therefore, there is a lot of hesitation with merging it for a minor improvement, which is itself not unanimously agreed on.

However, there is still the problem of the name conflict in godot-cpp GDExtension, which currently uses a work-around of using a function instead of a macro. This means that `print_verbose` in godot-cpp has different behavior compared to the macro in the engine, and is objectively slower for no good reason.

Because of this, I opened PR https://github.com/godotengine/godot/pull/106147 to add `PRINT_VERBOSE`, but @akien-mga suggested that if godot-cpp is the main motivation for making this change, we should see if the problem can be solved in godot-cpp.

This PR adds a capitalized `PRINT_VERBOSE` macro in parallel with the `print_verbose` function. This allows godot-cpp users to get the performance benefits of the macro. If users want to write C++ code that is compatible with both in-engine C++ and godot-cpp GDExtension C++, it is trivial to use `PRINT_VERBOSE` in an engine module like this:

```cpp
#if GODOT_MODULE
#define PRINT_VERBOSE print_verbose
#endif // GODOT_MODULE
```

Alternate design to consider: `GODOT_PRINT_VERBOSE` as the name.