### PR TITLE
Add header builders script for `env.GLSL_HEADER` and SVG icons

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -2,6 +2,7 @@ import os
 import platform
 import sys
 
+import header_builders
 from SCons import __version__ as scons_raw_version
 from SCons.Action import Action
 from SCons.Builder import Builder
@@ -529,6 +530,10 @@ def generate(env):
         BUILDERS={
             "GodotCPPBindings": Builder(action=Action(scons_generate_bindings, "$GENCOMSTR"), emitter=scons_emit_files),
             "GodotCPPDocData": Builder(action=scons_generate_doc_source),
+            "GLSL_HEADER": Builder(
+                action=header_builders.build_raw_headers_action,
+                suffix="glsl.gen.h",
+            ),
         }
     )
     env.AddMethod(_godot_cpp, "GodotCPP")

--- a/tools/header_builders.py
+++ b/tools/header_builders.py
@@ -1,0 +1,69 @@
+import os.path
+
+
+## See https://github.com/godotengine/godot/blob/master/glsl_builders.py
+def build_raw_header(source_filename: str, constant_name: str) -> None:
+    # Read the source file content.
+    with open(source_filename, "r") as source_file:
+        source_content = source_file.read()
+        constant_name = constant_name.replace(".", "_")
+        # Build header content using a C raw string literal.
+        header_content = (
+            "/* THIS FILE IS GENERATED. EDITS WILL BE LOST. */\n\n"
+            "#pragma once\n\n"
+            f"inline constexpr const char *{constant_name}"
+            " = "
+            f'R"<!>({source_content})<!>"'
+            ";\n"
+        )
+        # Write the header to the provided file name with a ".gen.h" suffix.
+        header_filename = f"{source_filename}.gen.h"
+        with open(header_filename, "w") as header_file:
+            header_file.write(header_content)
+
+
+def build_raw_headers_action(target, source, env):
+    env.NoCache(target)
+    for src in source:
+        source_filename = str(src)
+        # To match Godot, replace ".glsl" with "_shader_glsl". Does nothing for non-GLSL files.
+        constant_name = os.path.basename(source_filename).replace(".glsl", "_shader_glsl")
+        build_raw_header(source_filename, constant_name)
+
+
+def escape_svg(filename: str) -> str:
+    with open(filename, encoding="utf-8", newline="\n") as svg_file:
+        svg_content = svg_file.read()
+        return f'R"<!>({svg_content})<!>"'
+
+
+## See https://github.com/godotengine/godot/blob/master/editor/icons/editor_icons_builders.py
+## See https://github.com/godotengine/godot/blob/master/scene/theme/icons/default_theme_icons_builders.py
+def make_svg_icons_action(target, source, env):
+    destination = str(target[0])
+    constant_prefix = os.path.basename(destination).replace(".gen.h", "")
+    svg_icons = [str(x) for x in source]
+    # Convert the SVG icons to escaped strings and convert their names to C strings.
+    icon_names = [f'"{os.path.basename(fname)[:-4]}"' for fname in svg_icons]
+    icon_sources = [escape_svg(fname) for fname in svg_icons]
+    # Join them as indented comma-separated items for use in an array initializer.
+    icon_names_str = ",\n\t".join(icon_names)
+    icon_sources_str = ",\n\t".join(icon_sources)
+    # Write the file to disk.
+    with open(destination, "w", encoding="utf-8", newline="\n") as destination_file:
+        destination_file.write(
+            f"""\
+/* THIS FILE IS GENERATED. EDITS WILL BE LOST. */
+
+#pragma once
+
+inline constexpr int {constant_prefix}_count = {len(icon_names)};
+inline constexpr const char *{constant_prefix}_sources[] = {{
+	{icon_sources_str}
+}};
+
+inline constexpr const char *{constant_prefix}_names[] = {{
+	{icon_names_str}
+}};
+"""
+        )


### PR DESCRIPTION
Sometimes it is desired to have non-C++ files compiled into C++ code and available for use there. For example, you may want GLSL files available as Strings to be used at runtime. For example, you may want SVG files available as Strings to allow generating multiple sizes at runtime (important for the editor to be able to display things at any scale).

Each of these functionalities is already available when using a Godot engine module:

* For GLSL, you can use Godot's provided [`glsl_builders.py`](https://github.com/godotengine/godot/blob/master/glsl_builders.py) to generate these. This is exposed with `env.GLSL_HEADER`, meaning you call into it in a SConscript or SCsub like `env.GLSL_HEADER("path/to/some_file.glsl")` and it will generate a file `some_file.glsl.gen.h` with `inline constexpr const char *some_file_shader_glsl = ...` in it.
  * With GDExtension, without this PR, this has to be done manually.
* For SVG icons, Godot has two duplicated functions to generate [editor icons](https://github.com/godotengine/godot/blob/master/editor/icons/editor_icons_builders.py) and [default theme icons](https://github.com/godotengine/godot/blob/master/scene/theme/icons/default_theme_icons_builders.py). Icon generation happens "automatically", so modules do not need to call into it.
  * With GDExtension, the `[icons]` in the `.gdextension` file provides icons for classes. This fulfills the most common use case, however...
  * ...sometimes you need an icon that isn't tied to a class. Such icons are automatically available in modules.
    * With GDExtension, without this PR, this has to be done manually.
  * ...sometimes you need a resizeable icon, preserving the SVG source so it can be re-rasterized as needed.
    * With GDExtension, without this PR, this has to be done manually.

This PR adds a new file to the `tools` folder called `header_builders.py` which mimics the basic functionality of Godot's functions for GLSL header builders and SVG icon header builders. The GLSL header is used exactly like it is in the engine, with `env.GLSL_HEADER("path/to/some_file.glsl")`. This is registered in `godotcpp.py` with `"GLSL_HEADER": Builder(`.

As for the SVG icon builders, the engine does not provide an API for modules because it's supposed to be handled automatically, and so the function isn't needed in modules. Therefore, if the user needs non-class resizable SVG icons at runtime, calling into this function can be left as a godot-cpp-specific part of a user's buildsystem code, like this:

```py
import header_builders
target_file_path = "../../editor/icons/editor_4d_icons.gen.h"
icon_sources = Glob("icons/4D.svg") + Glob("icons/Node4D.svg")
header_builders.make_svg_icons_action([target_file_path], icon_sources, env)
```

Note that the code in this PR cannot simply be an exact copy of the engine functions. Those functions have many dependencies on other functions which are not necessary in GDExtension, such as the code to generate the copyright headers. The code in this PR is a lot simpler. Also, the code in this PR is much more generalized. The GLSL code in Godot is hard-coded for GLSL, but the function in this PR can be used for non-GLSL as well. As for the SVG icons, the code in the engine is duplicated for editor icons and default theme icons, and each is hard-coded for each of those, while the code in this PR will work with any destination file.

The motivation behind this PR is the needs of the Godot 4D module/extension, but this benefits all extensions.
