### PR TITLE
fix: missing `type_traits` include

### DIFF
--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -32,6 +32,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 
 namespace godot {


### PR DESCRIPTION
[Usage of `std::is_trivially_constructible` in `defs.hpp`](https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/defs.hpp#L326) requires [including `type_traits`](https://en.cppreference.com/w/cpp/types/is_constructible.html). 

This missing include leads to errors about that type not being found when building with clang++-22 with libc++-22 (which are not released yet), probably they changed the other header's transitive dependencies, making the issue suddenly visible.