### PR TITLE
Replace `std::list` and `std::set` with `List` and `HashSet`

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -45,9 +45,9 @@
 #include <godot_cpp/variant/callable_method_pointer.hpp>
 
 #include <godot_cpp/templates/a_hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/list.hpp>
 #include <mutex>
-#include <set>
 
 namespace godot {
 
@@ -86,10 +86,10 @@ public:
 		StringName parent_name;
 		GDExtensionInitializationLevel level = GDEXTENSION_INITIALIZATION_SCENE;
 		AHashMap<StringName, MethodBind *> method_map;
-		std::set<StringName> signal_names;
+		HashSet<StringName> signal_names;
 		AHashMap<StringName, VirtualMethod> virtual_methods;
-		std::set<StringName> property_names;
-		std::set<StringName> constant_names;
+		HashSet<StringName> property_names;
+		HashSet<StringName> constant_names;
 		// Pointer to the parent custom class, if any. Will be null if the parent class is a Godot class.
 		ClassInfo *parent_ptr = nullptr;
 	};

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -419,7 +419,7 @@ void ClassDB::initialize(GDExtensionInitializationLevel p_level) {
 }
 
 void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
-	std::set<StringName> to_erase;
+	HashSet<StringName> to_erase;
 	for (int i = class_register_order.size() - 1; i >= 0; --i) {
 		const StringName &name = class_register_order[i];
 		const ClassInfo &cl = classes[name];


### PR DESCRIPTION
std::list was being used in in one place for method args in class_db.hpp. This replaces it with Godot's List.

Also replaces std::set with HashSet.

This works fine but after looking at the code I'm pretty sure this shouldn't even be using a List at all. It's only used in MethodDefinition's args member but internally Godot uses a `Vector<StringName>` for this but godot-cpp is using a `List<StringName>`. godot-cpp's D_METHOD works different than the internal Godot one though so maybe this is intentional? Either way I don't want to make that change until https://github.com/godotengine/godot-cpp/pull/1841 gets merged as they will conflict.