### PR TITLE
Replace std::set with HashSet

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -46,9 +46,9 @@
 
 #include <godot_cpp/templates/local_vector.hpp>
 
+#include <godot_cpp/templates/hash_set.hpp>
 #include <list>
 #include <mutex>
-#include <set>
 #include <unordered_map>
 
 // Needed to use StringName as key in `std::unordered_map`
@@ -96,10 +96,10 @@ public:
 		StringName parent_name;
 		GDExtensionInitializationLevel level = GDEXTENSION_INITIALIZATION_SCENE;
 		std::unordered_map<StringName, MethodBind *> method_map;
-		std::set<StringName> signal_names;
+		HashSet<StringName> signal_names;
 		std::unordered_map<StringName, VirtualMethod> virtual_methods;
-		std::set<StringName> property_names;
-		std::set<StringName> constant_names;
+		HashSet<StringName> property_names;
+		HashSet<StringName> constant_names;
 		// Pointer to the parent custom class, if any. Will be null if the parent class is a Godot class.
 		ClassInfo *parent_ptr = nullptr;
 	};

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -410,7 +410,7 @@ void ClassDB::initialize(GDExtensionInitializationLevel p_level) {
 }
 
 void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
-	std::set<StringName> to_erase;
+	HashSet<StringName> to_erase;
 	for (int i = class_register_order.size() - 1; i >= 0; --i) {
 		const StringName &name = class_register_order[i];
 		const ClassInfo &cl = classes[name];


### PR DESCRIPTION
This removes all of the std::set usage and replaces it with Godot's RBSet.

I'm making this a draft for now because it will not compile until https://github.com/godotengine/godot-cpp/pull/1841 gets merged, but once it does it will work fine.