### PR TITLE
Specifically handle each "meta" value, so new ones don't break code generation

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2745,12 +2745,12 @@ def correct_typed_dictionary(type_name):
 def correct_type(type_name, meta=None, use_alias=True):
     type_conversion = {"float": "double", "int": "int64_t", "Nil": "Variant"}
     if meta is not None:
-        if "int" in meta:
+        if meta in ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]:
             return f"{meta}_t"
-        elif "char" in meta:
-            return f"{meta}_t"
-        else:
+        elif meta in ["float", "double"]:
             return meta
+        elif meta in ["char16", "char32"]:
+            return f"{meta}_t"
     if type_name in type_conversion:
         return type_conversion[type_name]
     if type_name.startswith("typedarray::"):


### PR DESCRIPTION
Originally, this PR specifically ignored the "required" meta that is added in PR https://github.com/godotengine/godot/pull/86079

However, I've decided to go a different way instead, and specifically address all the "meta" values we are aware of, so that things won't break in the future when new ones are added (including the "required" one)

This should make this safe to be merged even before that PR and cherry-pick it

## Original Description

This fixes issues in our code generation when used with Godot PR https://github.com/godotengine/godot/pull/86079

It basically just makes it ignore the "required" meta, which may be the right thing to do for godot-cpp, at least as far as handling APIs from Godot, although, this is something we should discuss.

But even if we do do that, we should still add `RequiredParam<T>` and `RequiredValue<T>` in godot-cpp for the purpose of marking APIs created in GDExtensions as having required parameters and values, but that can be a separate PR (since this one will need to be cherry-picked to Godot 4.5, but the further changes shouldn't be)