### PR TITLE
CMake: Fix missing -sUSE_PTHREADS=1 in web build

### DIFF
--- a/cmake/web.cmake
+++ b/cmake/web.cmake
@@ -21,7 +21,7 @@ function(web_generate)
     target_compile_options(
         godot-cpp
         PUBLIC #
-            -sSIDE_MODULE
+            -sSIDE_MODULE=1
             -sSUPPORT_LONGJMP=wasm
             $<${THREADS_ENABLED}:-sUSE_PTHREADS=1>
     )
@@ -33,6 +33,7 @@ function(web_generate)
             -sSUPPORT_LONGJMP=wasm
             -fvisibility=hidden
             -shared
+            $<${THREADS_ENABLED}:-sUSE_PTHREADS=1>
     )
 
     common_compiler_flags()


### PR DESCRIPTION
@lechaosx identified an issue with compiling for web using cmake in issue #1830

This led me to discover that there was a mising flag (`-sUSE_PTHREADS=1`) during the link stage that prevented godot from loading the library if threads were enabled.

This PR adds the missing flag, and adds a tiny change which brings it inline with scons.
- add -sUSE_PTHREADS=1 to link flags
- add =1 to sSIDE_MODULE=1 in compile flags to match scons.

The other proposed changes to cache the values of the emsdkHack.cmake are not going to solve the inclusion problem, as the special case for emscripten is that the values need to be injected as part of the project instantiation. This unfortunatley makes it that any project added for emscripten needs the include injection variable set prior to its definion.
```cmake
set(CMAKE_PROJECT_<my project name goes here>_INCLUDE ${godot-cpp_SOURCE_DIR}/cmake/emsdkHack.cmake)
```