### PR TITLE
Add smoke test with `Tween` to check for issues with handling `RefCounted`

### DIFF
--- a/test/build_profile.json
+++ b/test/build_profile.json
@@ -8,6 +8,7 @@
 		"OS",
 		"TileMap",
 		"TileSet",
+		"Tween",
 		"Viewport"
 	]
 }

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -225,6 +225,9 @@ func _ready():
 	assert_equal(new_tilemap.tile_set, new_tileset)
 	new_tilemap.queue_free()
 
+	# Creates a Tween and checks that it's valid. Improper refcount handling will crash now or at shutdown.
+	assert_equal(example.test_tween_smoke_test(), true)
+
 	# Test variant call.
 	var test_obj = TestClass.new()
 	assert_equal(example.test_variant_call(test_obj), "hello world")

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -222,6 +222,7 @@ void Example::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("test_add_child", "node"), &Example::test_add_child);
 	ClassDB::bind_method(D_METHOD("test_set_tileset", "tilemap", "tileset"), &Example::test_set_tileset);
+	ClassDB::bind_method(D_METHOD("test_tween_smoke_test"), &Example::test_tween_smoke_test);
 
 	ClassDB::bind_method(D_METHOD("test_variant_call", "variant"), &Example::test_variant_call);
 
@@ -614,6 +615,11 @@ void Example::test_add_child(Node *p_node) {
 
 void Example::test_set_tileset(TileMap *p_tilemap, const Ref<TileSet> &p_tileset) const {
 	p_tilemap->set_tileset(p_tileset);
+}
+
+bool Example::test_tween_smoke_test() {
+	Ref<Tween> tween = create_tween();
+	return tween.is_valid() && tween->is_class("Tween") && tween->get_reference_count() > 1;
 }
 
 Variant Example::test_variant_call(Variant p_variant) {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -19,6 +19,7 @@
 #include <godot_cpp/classes/input_event_key.hpp>
 #include <godot_cpp/classes/tile_map.hpp>
 #include <godot_cpp/classes/tile_set.hpp>
+#include <godot_cpp/classes/tween.hpp>
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/variant/typed_dictionary.hpp>
 #include <godot_cpp/variant/variant.hpp>
@@ -154,6 +155,7 @@ public:
 
 	void test_add_child(Node *p_node);
 	void test_set_tileset(TileMap *p_tilemap, const Ref<TileSet> &p_tileset) const;
+	bool test_tween_smoke_test();
 
 	Variant test_variant_call(Variant p_variant);
 


### PR DESCRIPTION
`Tween`s are an interesting case, because `Node::create_tween()` will return the new `Tween`, but also adds it to an internal list that will lead to it being processed later and eventually cleaned up.

If we have an issue with handling `RefCounted`, we may miss it on a simple function that just returns a `RefCounted`, but doesn't maintain another reference.

`Node::create_tween()` is also a fairly common method, so this is a good smoke test to have!

(Note: This test would have helped with https://github.com/godotengine/godot/pull/86079)