### PR TITLE
Disable "use_static_cpp" when "use_hot_reload" is enabled

### DIFF
--- a/tools/linux.py
+++ b/tools/linux.py
@@ -19,6 +19,8 @@ def generate(env):
     elif env.use_hot_reload:
         # Required for extensions to truly unload.
         env.Append(CXXFLAGS=["-fno-gnu-unique"])
+        # Reload won't work with "use_static_cpp", so disable it.
+        env["use_static_cpp"] = False
 
     env.Append(CCFLAGS=["-fPIC", "-Wwrite-strings"])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1876

This implements option nr 3 from that issue, but I wonder if option nr 1 would be better?

This PR ends up creating an inconsistency by default, where the debug template is built with `use_static_cpp=no` and the release template is built with `use_static_cpp=yes`

Perhaps this is the worst of all worlds?