### PR TITLE
On Linux default `use_static_cpp` to disabled

### DIFF
--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -15,7 +15,7 @@ function(linux_options)
         the docs (https://docs.godotengine.org/en/latest/tutorials/scripting/cpp/build_system/cmake.html)
         for examples.
     ]]
-    option(GODOTCPP_USE_STATIC_CPP "Link libgcc and libstdc++ statically for better portability" ON)
+    option(GODOTCPP_USE_STATIC_CPP "Link libgcc and libstdc++ statically for better portability" OFF)
 endfunction()
 
 #[===========================[ Target Generation ]===========================]

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -5,7 +5,7 @@ from SCons.Variables import BoolVariable
 
 def options(opts):
     opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler - only effective when targeting Linux", False))
-    opts.Add(BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True))
+    opts.Add(BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", False))
 
 
 def exists(env):


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1876

This implements option nr 1, which I guess I'm leaning to, because it's the least surprising. This option has only existed for a short time, so changing the default shouldn't be too big of a deal