### PR TITLE
Don't pollute when bulding multiple architectures

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -47,7 +47,13 @@ if unknown:
 
 scons_cache_path = os.environ.get("SCONS_CACHE")
 if scons_cache_path is not None:
-    CacheDir(scons_cache_path)
+    # Make the cache path unique for each platform and architecture
+    platform_arch = env["PLATFORM"] + "." + env["arch"]
+    platform_cache_path = os.path.join(scons_cache_path, platform_arch)
+    if not os.path.exists(platform_cache_path):
+        os.makedirs(platform_cache_path)
+
+    CacheDir(platform_cache_path)
     Decider("MD5")
 
 cpp_tool.generate(env)


### PR DESCRIPTION
I encountered this bug when I was building my mobile game for both Android and Windows.

But basically, when you do sequential multi-builds like this (logs from my own build system)

```bash
2025-11-09 09:29:05,234 [INFO] CppBuild: Running SCons: ./tools/venv/Scripts/scons platform=windows arch=x86_64 use_llvm=yes use_mingw=no target=template_release

2025-11-09 09:29:05,446 [INFO] CppBuild: Running SCons: ./tools/venv/Scripts/scons platform=android arch=x86 target=template_release

2025-11-09 09:30:54,205 [INFO] CppBuild: Running SCons: ./tools/venv/Scripts/scons platform=android arch=arm64 target=template_release

2025-11-09 09:32:57,873 [INFO] CppBuild: Running SCons: ./tools/venv/Scripts/scons platform=android arch=arm32 target=template_release

2025-11-09 09:33:03,918 [INFO] CppBuild: Running SCons: ./tools/venv/Scripts/scons platform=android arch=x86_64 target=template_release
```

The current code will pollute and corrupt each other's build objects. The MD5 decider was working correctly at a file level, but it had no context that the build flags (platform, arch) were different, leading to cache pollution (broken dll AND so files) that gave me quite the headache to find out.