### PR TITLE
CMake: Make -fno-exceptions private

### DIFF
--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -66,9 +66,6 @@ function(common_compiler_flags)
         # The public flag tells CMake that the following options are transient,
         # and will propagate to consumers.
         PUBLIC
-            # Disable exception handling. Godot doesn't use exceptions anywhere, and this
-            # saves around 20% of binary size and very significant build time.
-            $<${DISABLE_EXCEPTIONS}:$<${NOT_MSVC}:-fno-exceptions>>
 
             # Enabling Debug Symbols
             $<${DEBUG_SYMBOLS}:
@@ -95,6 +92,9 @@ function(common_compiler_flags)
 
         # Warnings below, these do not need to propagate to consumers.
         PRIVATE
+            # Disable exception handling. Godot doesn't use exceptions anywhere, and this
+            # saves around 20% of binary size and very significant build time.
+            $<${DISABLE_EXCEPTIONS}:$<${NOT_MSVC}:-fno-exceptions>>
             $<${IS_MSVC}:
                 /W4      # Warning level 4 (informational) warnings that aren't off by default.
 


### PR DESCRIPTION
This enables building a GDExtension with a third-party library that uses exceptions using CMake. Otherwise the -fno-exceptions` flag seems to extend to everything.

Some context: I'm trying to make a GDExtension that integrates the Orbecc SDK in Godot. This SDK is open source and uses exceptions. I had to make this change to successfully build it along with godot-cpp using CMake.

I am by no means good at CMake so tell me if I'm missing something obvious.

Thanks for all your work !