### PR TITLE
Fix ClassDB crash caused by HashMap reallocation invalidating parent_ptr

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -90,8 +90,6 @@ public:
 		AHashMap<StringName, VirtualMethod> virtual_methods;
 		std::set<StringName> property_names;
 		std::set<StringName> constant_names;
-		// Pointer to the parent custom class, if any. Will be null if the parent class is a Godot class.
-		ClassInfo *parent_ptr = nullptr;
 	};
 
 private:
@@ -233,11 +231,6 @@ void ClassDB::_register_class(bool p_virtual, bool p_exposed, bool p_runtime) {
 	cl.name = T::get_class_static();
 	cl.parent_name = T::get_parent_class_static();
 	cl.level = current_level;
-	AHashMap<StringName, ClassInfo>::Iterator parent_it = classes.find(cl.parent_name);
-	if (parent_it != classes.end()) {
-		// Assign parent if it is also a custom class
-		cl.parent_ptr = &parent_it->value;
-	}
 	classes[cl.name] = cl;
 	class_register_order.push_back(cl.name);
 

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -118,8 +118,13 @@ MethodBind *ClassDB::get_method(const StringName &p_class, const StringName &p_m
 		if (method != type->method_map.end()) {
 			return method->value;
 		}
-		type = type->parent_ptr;
-		continue;
+
+		AHashMap<StringName, ClassInfo>::Iterator parent_it = classes.find(type->parent_name);
+		if (parent_it == classes.end()) {
+			break;
+		}
+
+		type = &parent_it->value;
 	}
 
 	return nullptr;
@@ -243,7 +248,13 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 	ClassInfo *check = &cl;
 	while (check) {
 		ERR_FAIL_COND_MSG(check->signal_names.find(p_signal.name) != check->signal_names.end(), String("Class '{0}' already has signal '{1}'.").format(Array::make(p_class, p_signal.name)));
-		check = check->parent_ptr;
+
+		AHashMap<StringName, ClassInfo>::Iterator parent_it = classes.find(check->parent_name);
+		if (parent_it == classes.end()) {
+			break;
+		}
+
+		check = &parent_it->value;
 	}
 
 	// register our signal in our plugin
@@ -303,7 +314,12 @@ GDExtensionClassCallVirtual ClassDB::get_virtual_func(void *p_userdata, GDExtens
 			return method_it->value.func;
 		}
 
-		type = type->parent_ptr;
+		AHashMap<StringName, ClassInfo>::Iterator parent_it = classes.find(type->parent_name);
+		if (parent_it == classes.end()) {
+			break;
+		}
+
+		type = &parent_it->value;
 	}
 
 	return nullptr;


### PR DESCRIPTION
**Issue:** 
Currently, ClassInfo stores a parent_ptr that points to the parent class's entry inside the global classes HashMap. However, HashMap stores elements contiguously. When new classes are registered and the map exceeds its capacity, it triggers a resize/reallocation. This moves all existing ClassInfo objects to new memory addresses. Any existing parent_ptr held by child classes becomes a dangling pointer to freed memory. This causes random crashes in get_virtual_func when looking up parent methods, depending on registration order and memory reuse.

**Proposed Fix:** 
Remove parent_ptr and replace it with a dynamic lookup using classes.find(parent_name).

This is the first time doing any kind of pull-requests so if anything looks wrong please let me know.