### PR TITLE
Make `ClassDB::classes` pointer-stable again by changing it to `HashMap`

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -96,7 +96,7 @@ public:
 
 private:
 	// This may only contain custom classes, not Godot classes
-	static AHashMap<StringName, ClassInfo> classes;
+	static HashMap<StringName, ClassInfo> classes;
 	static AHashMap<StringName, const GDExtensionInstanceBindingCallbacks *> instance_binding_callbacks;
 	// Used to remember the custom class registration order.
 	static LocalVector<StringName> class_register_order;
@@ -233,7 +233,7 @@ void ClassDB::_register_class(bool p_virtual, bool p_exposed, bool p_runtime) {
 	cl.name = T::get_class_static();
 	cl.parent_name = T::get_parent_class_static();
 	cl.level = current_level;
-	AHashMap<StringName, ClassInfo>::Iterator parent_it = classes.find(cl.parent_name);
+	HashMap<StringName, ClassInfo>::Iterator parent_it = classes.find(cl.parent_name);
 	if (parent_it != classes.end()) {
 		// Assign parent if it is also a custom class
 		cl.parent_ptr = &parent_it->value;
@@ -330,7 +330,7 @@ MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, StringName p_name, M p
 
 	StringName instance_type = bind->get_instance_class();
 
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(instance_type);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(instance_type);
 	if (type_it == classes.end()) {
 		memdelete(bind);
 		ERR_FAIL_V_MSG(nullptr, String("Class '{0}' doesn't exist.").format(Array::make(instance_type)));

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -38,7 +38,7 @@
 
 namespace godot {
 
-AHashMap<StringName, ClassDB::ClassInfo> ClassDB::classes;
+HashMap<StringName, ClassDB::ClassInfo> ClassDB::classes;
 AHashMap<StringName, const GDExtensionInstanceBindingCallbacks *> ClassDB::instance_binding_callbacks;
 LocalVector<StringName> ClassDB::class_register_order;
 AHashMap<StringName, Object *> ClassDB::engine_singletons;
@@ -128,7 +128,7 @@ MethodBind *ClassDB::get_method(const StringName &p_class, const StringName &p_m
 MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const MethodDefinition &method_name, const void **p_defs, int p_defcount) {
 	StringName instance_type = p_bind->get_instance_class();
 
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(instance_type);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(instance_type);
 	if (type_it == classes.end()) {
 		memdelete(p_bind);
 		ERR_FAIL_V_MSG(nullptr, String("Class '{0}' doesn't exist.").format(Array::make(instance_type)));
@@ -233,7 +233,7 @@ void ClassDB::bind_method_godot(const StringName &p_class_name, MethodBind *p_me
 }
 
 void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) {
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class);
 
 	ERR_FAIL_COND_MSG(type_it == classes.end(), String("Class '{0}' doesn't exist.").format(Array::make(p_class)));
 
@@ -268,7 +268,7 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 }
 
 void ClassDB::bind_integer_constant(const StringName &p_class_name, const StringName &p_enum_name, const StringName &p_constant_name, GDExtensionInt p_constant_value, bool p_is_bitfield) {
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class_name);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class_name);
 
 	ERR_FAIL_COND_MSG(type_it == classes.end(), String("Class '{0}' doesn't exist.").format(Array::make(p_class_name)));
 
@@ -290,7 +290,7 @@ GDExtensionClassCallVirtual ClassDB::get_virtual_func(void *p_userdata, GDExtens
 	const StringName *class_name = reinterpret_cast<const StringName *>(p_userdata);
 	const StringName *name = reinterpret_cast<const StringName *>(p_name);
 
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(*class_name);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(*class_name);
 	ERR_FAIL_COND_V_MSG(type_it == classes.end(), nullptr, String("Class '{0}' doesn't exist.").format(Array::make(*class_name)));
 
 	const ClassInfo *type = &type_it->value;
@@ -327,7 +327,7 @@ const GDExtensionInstanceBindingCallbacks *ClassDB::get_instance_binding_callbac
 }
 
 void ClassDB::bind_virtual_method(const StringName &p_class, const StringName &p_method, GDExtensionClassCallVirtual p_call, uint32_t p_hash) {
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class);
 	ERR_FAIL_COND_MSG(type_it == classes.end(), String("Class '{0}' doesn't exist.").format(Array::make(p_class)));
 
 	ClassInfo &type = type_it->value;
@@ -342,7 +342,7 @@ void ClassDB::bind_virtual_method(const StringName &p_class, const StringName &p
 }
 
 void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_method, const Vector<StringName> &p_arg_names) {
-	AHashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class);
+	HashMap<StringName, ClassInfo>::Iterator type_it = classes.find(p_class);
 	ERR_FAIL_COND_MSG(type_it == classes.end(), String("Class '{0}' doesn't exist.").format(Array::make(p_class)));
 
 	GDExtensionClassVirtualMethodInfo mi;


### PR DESCRIPTION
- Alternative to https://github.com/godotengine/godot-cpp/pull/1886
- Should fix https://github.com/godotengine/godot-cpp/issues/1884
- Should fix https://github.com/godotengine/godot-cpp/issues/1873
- Should fix https://github.com/godotengine/godot-cpp/issues/1862
- Fixes regression from #1839

I'm not sure why I haven't thought of this problem when suggesting to use `AHashMap` for #1839, or noticed it on any of the issues that popped up. That was a blunder on my part. Sorry, folks!

The problem materializes (in potentially various semi-related ways) as soon as at least ~13 classes are registered.

### Explanation

`ClassDB::classes` holds `ClassInfo` densely. That means that on every resize, the `ClassInfo` structs move in memory, which makes pointers to them illegal.
@SiimonDev correctly identified this as a source of failure, and in https://github.com/godotengine/godot-cpp/pull/1886 fixes some issues by removing pointers to the `ClassInfo` structs.
However, I think it is expected that the `ClassInfo` structs have stable locations in memory. Not being able to hold pointers to it could be a significant performance burden.

Stable memory locations could be accomplished by either using `HashMap` (see pointer stability in [Core types](https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers)), like Godot (https://github.com/godotengine/godot/blob/9dd6c4dbac70b28e8156255c3a2b78722772b036/core/object/class_db.h#L204), or by changing it to hold `ClassInfo *` (like the current state of https://github.com/godotengine/godot/pull/106646).
I'm not fully convinced of the benefits of using `AHashMap` when we're using allocations with values anyway, which is why I'm hesitant to merge https://github.com/godotengine/godot/pull/106646 right now. So that's why Godot upstream is still using `HashMap`.

Long story short, `HashMap` guarantees pointer stability, which should fix the problem.