### PR TITLE
Align Emscripten version 4.0.11 with Godot Engine

### DIFF
--- a/.github/actions/setup-godot-cpp/action.yml
+++ b/.github/actions/setup-godot-cpp/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
     description: Target platform.
   em-version:
-    default: 3.1.62
+    default: 4.0.11
     description: Emscripten version.
   windows-compiler:
     required: true

--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -20,7 +20,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
-      EM_VERSION: 3.1.39
+      EM_VERSION: 4.0.11
       config-flags:
         -DCMAKE_C_COMPILER_LAUNCHER=sccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=sccache

--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -87,7 +87,7 @@ jobs:
 
     env:
       SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
-      EM_VERSION: 3.1.39
+      EM_VERSION: 4.0.11
 
     steps:
       - name: Checkout


### PR DESCRIPTION
@dsnopek as discussed. This should be backported to the 4.5 branch, as Godot aligned with Emscripten 4.0.11 with the release of Godot 4.5.