### PR TITLE
void is a valid return type that should not require documentation

### DIFF
--- a/make_interface_header.py
+++ b/make_interface_header.py
@@ -237,7 +237,7 @@ def check_type(kind, type, valid_data_types):
             if not is_valid_type(arg["type"], valid_data_types):
                 raise UnknownTypeError(arg["type"], type["name"], arg.get("name"))
         if "return_value" in type:
-            if not is_valid_type(type["return_value"]["type"], valid_data_types):
+            if not base_type_name(type["return_value"]["type"]) in valid_data_types:
                 raise UnknownTypeError(type["return_value"]["type"], type["name"])
 
 
@@ -341,7 +341,7 @@ def write_interface(file, interface):
             arg_doc = " ".join(arg["description"])
             doc.append(f"@param {arg['name']} {arg_doc}")
 
-    if "return_value" in interface:
+    if "return_value" in interface and interface["return_value"]["type"] != "void":
         if "description" not in interface["return_value"]:
             raise Exception(f"Interface function {interface['name']} is missing docs for return value")
         ret_doc = " ".join(interface["return_value"]["description"])


### PR DESCRIPTION
After getting latest, I was unable to generate the bindings due to the following errors:

```
make_interface_header.UnknownTypeError: Unknown type 'void' used in 'GDExtensionVariantFromTypeConstructorFunc'
```

And once that was fixed:

```
Exception: Interface function get_godot_version is missing docs for return value
```

It seems reasonable that a function should support void as a return type, and that this return type would not need documentation. This PR makes those alterations.