### PR TITLE
Removed unused variable

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -320,7 +320,6 @@ public:                                                                         
                                                                                                                                                                                        \
 	static void free_property_list_bind(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t /*p_count*/) {                                         \
 		if (p_instance) {                                                                                                                                                              \
-			m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                    \
 			::godot::internal::free_c_property_list(const_cast<GDExtensionPropertyInfo *>(p_list));                                                                                    \
 		}                                                                                                                                                                              \
 	}                                                                                                                                                                                  \


### PR DESCRIPTION
Hi
I'm compiling with `-Wpedantic` and gcc is throwing the warning:

```
/home/saleem/GodotProjects/project/backend/include/scenes/example_scene.h:8:2: error: unused variable 'cls' [-Werror,-Wunused-variable]
    8 |         GDCLASS(ExampleScene, Control)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/saleem/software/godot/godot-cpp/include/godot_cpp/classes/wrapped.hpp:323:13: note: expanded from macro 'GDCLASS'
  323 |                         m_class *cls = reinterpret_cast<m_class *>(p_instance)...
      |                                  ^~~
1 error generated.
```