### PR TITLE
Apply singleton instance binding clean-up fix no matter how it is created

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2078,6 +2078,7 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
     result = []
 
     class_name = class_api["name"]
+    inherits = class_api["inherits"] if "inherits" in class_api else "Wrapped"
     snake_class_name = camel_to_snake(class_name)
     is_singleton = class_name in singletons
 
@@ -2117,17 +2118,23 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
         result.append("#ifdef DEBUG_ENABLED")
         result.append("\t\tERR_FAIL_NULL_V(singleton_obj, nullptr);")
         result.append("#endif // DEBUG_ENABLED")
+        # This will lead to the constructor which will set `singleton`.
         result.append(
-            f"\t\tsingleton = reinterpret_cast<{class_name} *>(::godot::gdextension_interface::object_get_instance_binding(singleton_obj, ::godot::gdextension_interface::token, &{class_name}::_gde_binding_callbacks));"
+            f"\t\t::godot::gdextension_interface::object_get_instance_binding(singleton_obj, ::godot::gdextension_interface::token, &{class_name}::_gde_binding_callbacks);"
         )
         result.append("#ifdef DEBUG_ENABLED")
         result.append("\t\tERR_FAIL_NULL_V(singleton, nullptr);")
         result.append("#endif // DEBUG_ENABLED")
-        result.append("\t\tif (likely(singleton)) {")
-        result.append(f"\t\t\tClassDB::_register_engine_singleton({class_name}::get_class_static(), singleton);")
-        result.append("\t\t}")
         result.append("\t}")
         result.append("\treturn singleton;")
+        result.append("}")
+        result.append("")
+
+        result.append(f"{class_name}::{class_name}(GodotObject *p_godot_object) : {inherits}(p_godot_object) {{")
+        result.append("\tif (singleton == nullptr) {")
+        result.append("\t\tsingleton = this;")
+        result.append(f"\t\tClassDB::_register_engine_singleton({class_name}::get_class_static(), singleton);")
+        result.append("\t}")
         result.append("}")
         result.append("")
 
@@ -2136,6 +2143,10 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
         result.append(f"\t\tClassDB::_unregister_engine_singleton({class_name}::get_class_static());")
         result.append("\t\tsingleton = nullptr;")
         result.append("\t}")
+        result.append("}")
+        result.append("")
+    else:
+        result.append(f"{class_name}::{class_name}(GodotObject *p_godot_object) : {inherits}(p_godot_object) {{")
         result.append("}")
         result.append("")
 

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -434,7 +434,7 @@ private: \
 \
 protected: \
 	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {} \
-	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {} \
+	m_class(GodotObject *p_godot_object); \
 \
 	static void _bind_methods() {} \
 \

--- a/test/build_profile.json
+++ b/test/build_profile.json
@@ -11,6 +11,7 @@
 		"TileMap",
 		"TileSet",
 		"Tween",
-		"Viewport"
+		"Viewport",
+		"XRServer"
 	]
 }

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -276,8 +276,9 @@ func _ready():
 	assert_equal(example.test_virtual_implemented_in_script("Virtual", 939), "Implemented")
 	assert_equal(custom_signal_emitted, ["Virtual", 939])
 
-	# Test that we can access an engine singleton.
-	assert_equal(example.test_use_engine_singleton(), OS.get_name())
+	# Test that we can access an engine singletons.
+	assert_equal(example.test_use_engine_singleton1(), OS.get_name())
+	assert_equal(example.test_use_engine_singleton2(), true)
 
 	# Test that we can access the SceneTree singleton.
 	assert_equal(example.test_use_scene_tree_singleton(), true)

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -7,12 +7,14 @@
 
 #include <godot_cpp/core/class_db.hpp>
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/classes/label.hpp>
 #include <godot_cpp/classes/multiplayer_api.hpp>
 #include <godot_cpp/classes/multiplayer_peer.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
@@ -266,8 +268,9 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("test_virtual_implemented_in_script"), &Example::test_virtual_implemented_in_script);
 	GDVIRTUAL_BIND(_do_something_virtual_with_control, "control");
 
-	ClassDB::bind_method(D_METHOD("test_use_engine_singleton"), &Example::test_use_engine_singleton);
 	ClassDB::bind_method(D_METHOD("test_use_scene_tree_singleton"), &Example::test_use_scene_tree_singleton);
+	ClassDB::bind_method(D_METHOD("test_use_engine_singleton1"), &Example::test_use_engine_singleton1);
+	ClassDB::bind_method(D_METHOD("test_use_engine_singleton2"), &Example::test_use_engine_singleton2);
 
 	ClassDB::bind_method(D_METHOD("test_get_internal_class"), &Example::test_get_internal_class);
 
@@ -757,13 +760,18 @@ String Example::test_virtual_implemented_in_script(const String &p_name, int p_v
 	return "Unimplemented";
 }
 
-String Example::test_use_engine_singleton() const {
-	return OS::get_singleton()->get_name();
-}
-
 bool Example::test_use_scene_tree_singleton() const {
 	SceneTree *scene_tree = SceneTree::get_singleton();
 	return scene_tree != nullptr && scene_tree == get_tree();
+}
+
+String Example::test_use_engine_singleton1() const {
+	return OS::get_singleton()->get_name();
+}
+
+bool Example::test_use_engine_singleton2() const {
+	XRServer *xr_server = Object::cast_to<XRServer>(Engine::get_singleton()->get_singleton("XRServer"));
+	return xr_server != nullptr;
 }
 
 String Example::test_library_path() {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -216,6 +216,9 @@ public:
 	String test_use_engine_singleton() const;
 	bool test_use_scene_tree_singleton() const;
 
+	String test_use_engine_singleton1() const;
+	bool test_use_engine_singleton2() const;
+
 	static String test_library_path();
 
 	Ref<RefCounted> test_get_internal_class() const;


### PR DESCRIPTION
This was originally created in an attempt to address https://github.com/godotengine/godot-cpp/issues/1900

It does fix a crash that I'm able to reproduce when accessing a singleton via `Engine::get_singleton()->get_singleton("Name")` which I've added a test for.

This fix is a little weird in that it only addresses the `Wrapped(GodotObject *)` constructor, but I think that's actually correct, because we only want to do this when the instance binding creation was initiated on the engine side using a pre-existing instance. If someone creates a new instance of a singleton (which they really shouldn't do, but there's nothing preventing it) then it shouldn't register that as an engine singleton.

However, it seems it's still possible to reproduce #1900 even with this PR