### PR TITLE
Filter conflicting global constants

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2259,8 +2259,24 @@ def generate_global_constants(api, output_dir):
     header.append("namespace godot {")
     header.append("")
 
-    if len(api["global_constants"]) > 0:
-        for constant in api["global_constants"]:
+    # Remove integer limit global constants that overlap with those defined in cstdint
+    limit_constants = {
+        "UINT8_MAX",
+        "UINT16_MAX",
+        "UINT32_MAX",
+        "INT8_MIN",
+        "INT8_MAX",
+        "INT16_MIN",
+        "INT16_MAX",
+        "INT32_MIN",
+        "INT32_MAX",
+        "INT64_MIN",
+        "INT64_MAX",
+    }
+    global_constants = [c for c in api["global_constants"] if c["name"] not in limit_constants]
+
+    if len(global_constants) > 0:
+        for constant in global_constants:
             header.append(f"const int64_t {escape_identifier(constant['name'])} = {constant['value']};")
 
         header.append("")


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/115649.

In order to add integer limits to @GlobalScope constants, we'll need to ignore them in the generated _godot-cpp/gen/include/godot_cpp/classes/global_constants.hpp_. These constants conflict with macros defined in `cstdint` e.g. `UINT8_MAX` (see [cstdint docs](https://en.cppreference.com/w/cpp/header/cstdint.html)).