### PR TITLE
improve architecture detection for cross-compilation

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -64,6 +64,20 @@ function(godot_arch_name OUTVAR)
         endif()
     endif()
 
+    # Special case for MSVC cross-compilation
+    if(DEFINED CMAKE_VS_PLATFORM_NAME)
+        if(CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
+            set(${OUTVAR} "x86_32" PARENT_SCOPE)
+            return()
+        elseif(CMAKE_VS_PLATFORM_NAME STREQUAL "x64")
+            set(${OUTVAR} "x86_64" PARENT_SCOPE)
+            return()
+        elseif(CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64")
+            set(${OUTVAR} "arm64" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
     # Direct match early out.
     string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" ARCH)
     if(ARCH IN_LIST ARCH_LIST)


### PR DESCRIPTION
While working on cross-compilation setups, I ran into a few cases where godot_arch_name() fails to detect the intended target architecture because CMAKE_SYSTEM_PROCESSOR is host instead of the target.

This shows up in a couple of fairly common scenarios:

- MSVC cross-compilation: when using Visual Studio generators, CMAKE_SYSTEM_PROCESSOR isn’t set, but CMAKE_VS_PLATFORM_NAME reliably reflects the selected target (Win32, x64, ARM64)
- GCC multilib (-m32): building 32-bit binaries on an x86_64 host keeps CMAKE_SYSTEM_PROCESSOR at x86_64
- ARM Linux toolchains (e.g. gcc-arm-linux-gnueabihf): some toolchains set CMAKE_SYSTEM_PROCESSOR to the generic arm, which previously didn’t match any known aliases and caused detection to fail

I’m not entirely sure whether all of this should live here or whether some of it would be better handled by toolchain files (especially setting CMAKE_SYSTEM_PROCESSOR correctly). Also, Linux ARM32 and x86_32, as well as Windows x86_32, are probably not heavily used targets anymore.