### PR TITLE
Style: Convert `*.gen.inc` to `*.hpp` for ninja

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -221,8 +221,8 @@ def _get_file_list(api, output_dir, headers=False, sources=False):
     files.append(str((gdextension_gen_folder / "gdextension_interface.h").as_posix()))
     files.append(str((core_gen_folder / "gdextension_interface_loader.hpp").as_posix()))
     files.append(str((source_gen_folder / "gdextension_interface_loader.cpp").as_posix()))
-    files.append(str((core_gen_folder / "ext_wrappers.gen.inc").as_posix()))
-    files.append(str((core_gen_folder / "gdvirtual.gen.inc").as_posix()))
+    files.append(str((core_gen_folder / "ext_wrappers.hpp").as_posix()))
+    files.append(str((core_gen_folder / "gdvirtual.hpp").as_posix()))
 
     for builtin_class in api["builtin_classes"]:
         if is_pod_type(builtin_class["name"]):
@@ -513,8 +513,8 @@ def generate_builtin_bindings(api, output_dir, build_config):
     include_gen_folder.mkdir(parents=True, exist_ok=True)
     source_gen_folder.mkdir(parents=True, exist_ok=True)
 
-    generate_wrappers(core_gen_folder / "ext_wrappers.gen.inc")
-    generate_virtuals(core_gen_folder / "gdvirtual.gen.inc")
+    generate_wrappers(core_gen_folder / "ext_wrappers.hpp")
+    generate_virtuals(core_gen_folder / "gdvirtual.hpp")
 
     # Store types beforehand.
     for builtin_api in api["builtin_classes"]:

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -29,7 +29,7 @@
 #endif // GODOT_VERSION_MINOR >= 4
 
 #include <godot_cpp/core/binder_common.hpp>
-#include <godot_cpp/core/gdvirtual.gen.inc>
+#include <godot_cpp/core/gdvirtual.hpp>
 
 using namespace godot;
 


### PR DESCRIPTION
- Related: godotengine/godot#115935

While less pertinent on godot-cpp, the same issue could theoretically occur, so this moves away from the `.inc` syntax for generated headers. However, the context of generating files in godot-cpp is much different than godot, so the extension is `.hpp` instead of `.gen.h`, as the `.gen` paradigm isn't needed when we have a dedicated folder for generated files