### PR TITLE
Cherry-pick #1904: fix _get_property_list failing in thread scenarios

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -105,10 +105,6 @@ protected:
 	static GDExtensionBool validate_property_bind(GDExtensionClassInstancePtr p_instance, GDExtensionPropertyInfo *p_property) { return false; }
 	static void to_string_bind(GDExtensionClassInstancePtr p_instance, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out) {}
 
-	// The only reason this has to be held here, is when we return results of `_get_property_list` to Godot, we pass
-	// pointers to strings in this list. They have to remain valid to pass the bridge, until the list is freed by Godot...
-	::godot::List<::godot::PropertyInfo> plist_owned;
-
 	void _postinitialize();
 
 	Wrapped(const StringName &p_godot_class);
@@ -155,7 +151,7 @@ _FORCE_INLINE_ Vector<StringName> snarray(P... p_args) {
 
 namespace internal {
 
-GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::PropertyInfo> &plist_cpp, uint32_t *r_size);
+GDExtensionPropertyInfo *create_c_property_list(::godot::List<::godot::PropertyInfo> *plist_cpp, uint32_t *r_size);
 void free_c_property_list(GDExtensionPropertyInfo *plist);
 
 typedef void (*EngineClassRegistrationCallback)();
@@ -316,16 +312,14 @@ public:                                                                         
 			return nullptr;                                                                                                                                                            \
 		}                                                                                                                                                                              \
 		m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                        \
-		::godot::List<::godot::PropertyInfo> &plist_cpp = cls->plist_owned;                                                                                                            \
-		ERR_FAIL_COND_V_MSG(!plist_cpp.is_empty(), nullptr, "Internal error, property list was not freed by engine!");                                                                 \
-		cls->_get_property_list(&plist_cpp);                                                                                                                                           \
+		::godot::List<::godot::PropertyInfo> *plist_cpp = memnew(::godot::List<::godot::PropertyInfo>);                                                                                \
+		cls->_get_property_list(plist_cpp);                                                                                                                                            \
 		return ::godot::internal::create_c_property_list(plist_cpp, r_count);                                                                                                          \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static void free_property_list_bind(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t /*p_count*/) {                                         \
 		if (p_instance) {                                                                                                                                                              \
 			m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                    \
-			cls->plist_owned.clear();                                                                                                                                                  \
 			::godot::internal::free_c_property_list(const_cast<GDExtensionPropertyInfo *>(p_list));                                                                                    \
 		}                                                                                                                                                                              \
 	}                                                                                                                                                                                  \

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -105,16 +105,21 @@ std::vector<EngineClassRegistrationCallback> &get_engine_class_registration_call
 	return engine_class_registration_callbacks;
 }
 
-GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::PropertyInfo> &plist_cpp, uint32_t *r_size) {
-	GDExtensionPropertyInfo *plist = nullptr;
+GDExtensionPropertyInfo *create_c_property_list(::godot::List<::godot::PropertyInfo> *plist_cpp, uint32_t *r_size) {
 	// Linked list size can be expensive to get so we cache it
-	const uint32_t plist_size = plist_cpp.size();
+	const uint32_t plist_size = plist_cpp->size();
 	if (r_size != nullptr) {
 		*r_size = plist_size;
 	}
-	plist = reinterpret_cast<GDExtensionPropertyInfo *>(memalloc(sizeof(GDExtensionPropertyInfo) * plist_size));
+
+	// Use the padding to stash the plist_cpp pointer, so we can clean it up later.
+	void *mem = ::godot::Memory::alloc_static(sizeof(GDExtensionPropertyInfo) * plist_size, true);
+	GDExtensionPropertyInfo *plist = reinterpret_cast<GDExtensionPropertyInfo *>(mem);
+	::godot::List<::godot::PropertyInfo> **plist_cpp_stash = reinterpret_cast<::godot::List<::godot::PropertyInfo> **>((uint8_t *)mem - ::godot::Memory::DATA_OFFSET + ::godot::Memory::ELEMENT_OFFSET);
+	*plist_cpp_stash = plist_cpp;
+
 	unsigned int i = 0;
-	for (const ::godot::PropertyInfo &E : plist_cpp) {
+	for (const ::godot::PropertyInfo &E : *plist_cpp) {
 		plist[i].type = static_cast<GDExtensionVariantType>(E.type);
 		plist[i].name = E.name._native_ptr();
 		plist[i].hint = E.hint;
@@ -127,7 +132,10 @@ GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::Pro
 }
 
 void free_c_property_list(GDExtensionPropertyInfo *plist) {
-	memfree(plist);
+	// Get the stashed plist_cpp pointer, before we free the memory that's holding it.
+	::godot::List<::godot::PropertyInfo> *plist_cpp = *reinterpret_cast<::godot::List<::godot::PropertyInfo> **>((uint8_t *)plist - ::godot::Memory::DATA_OFFSET + ::godot::Memory::ELEMENT_OFFSET);
+	::godot::Memory::free_static(plist, true);
+	memdelete(plist_cpp);
 }
 
 void add_engine_class_registration_callback(EngineClassRegistrationCallback p_callback) {


### PR DESCRIPTION
My latest extension build still uses GodotCpp from the `godot-4.5-stable` tag for compatibility, but is crashing in Godot 4.6 when expanding custom resources in the inspector (call stack indicates it's not the main thread):
<img width="1776" height="331" alt="image" src="https://github.com/user-attachments/assets/78816603-bd9c-493e-bf0e-7c665fe61fd4" />
With a similar error in the console:
```
ERROR: Internal error, property list was not freed by engine!
   at: zylann::voxel::VoxelBlockyModelCube::get_property_list_bind (D:\Projets\Info\Godot\Engine\godot4_fork\modules\voxel\meshers/blocky/voxel_blocky_model_cube.h:11)
```
That #1904 seems to fix.

Btw, should I then use the `4.5` branch instead of the `godot-4.5-stable` tag when building releases? Given fixes may have been done, it seems tags are a bit useless besides marking the "first version supporting Godot x.x"