### PR TITLE
Support binding math constants

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2917,6 +2917,13 @@ def correct_default_value(value, type_name):
         "{}": "Dictionary()",
         "Transform2D(1, 0, 0, 1, 0, 0)": "Transform2D()",  # Default transform.
         "Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)": "Transform3D()",  # Default transform.
+        "pi": "Math_PI",
+        "-pi": "-Math_PI",
+        "tau": "Math_TAU",
+        "-tau": "-Math_TAU",
+        "inf": "Math_INF",
+        "-inf": "-Math_INF",
+        "nan": "Math_NAN",
     }
     if value in value_map:
         return value_map[value]


### PR DESCRIPTION
- [Relevant RC Thread](https://chat.godotengine.org/channel/gdextension?msg=Yz93YXDAgTeXQmeDE)

Enables the ability to bind `±pi`, `±tau`, `±inf`, and `nan` values. Previously the binding generator would try to pass these aliases directly to C++, causing build errors:
```
Error: /home/runner/work/godot/godot/godot-cpp/gen/include/godot_cpp/classes/tween.hpp:117:72: error: 'inf' was not declared in this scope; did you mean 'ynf'?
  117 |         Ref<Tween> set_trans_params(double p_param1, double p_param2 = inf);
      |                                                                        ^~~
      |                                                                        ynf
```
After these changes, this would result in:
```cpp
Ref<Tween> set_trans_params(double p_param1, double p_param2 = Math_INF);
```