### PR TITLE
Sync `Ref` to godotengine master.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1676,6 +1676,8 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
         used_classes = list(used_classes)
         used_classes.sort()
         fully_used_classes = list(fully_used_classes)
+        if class_api["name"] == "RefCounted":
+            fully_used_classes.remove("Ref")  # Special case; Ref should include RefCounted but not vice versa.
         fully_used_classes.sort()
 
         with header_filename.open("w+", encoding="utf-8") as header_file:


### PR DESCRIPTION
I deleted a few comments that aren't relelvant in godot-cpp, the rest is godotengine/master verbatim.

To make it work, I needed to flip the `Ref` <-> `RefCounted` dependency, such that `Ref` knows `RefCounted` but not vice versa. This matches the setup from upstream Godot.

Should fix #1938 