### PR TITLE
Fix variadic version of the callp_static method of the Variant class.

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -299,7 +299,7 @@ public:
 		}
 		Variant result;
 		GDExtensionCallError error;
-		callp_static(type, method, argptrs.data(), argptrs.size(), sizeof...(args), result, error);
+		callp_static(type, method, argptrs.data(), argptrs.size(), result, error);
 		return result;
 	}
 


### PR DESCRIPTION
Remove the extra parameter causing a compilation error ('godot::Variant::callp_static': function does not take 7 arguments) when using the variadic version of the callp_static method of the Variant class.
The number of arguments was given twice in two different forms (size of the array and the number of variadic arguments).