### PR TITLE
Bindable CXX lambdas as methods in classes

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -37,6 +37,7 @@
 #include <godot_cpp/core/type_info.hpp>
 
 #include <array>
+#include <functional>
 
 namespace godot {
 
@@ -208,6 +209,26 @@ void call_with_ptr_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const,
 	PtrToArg<R>::encode((p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...), r_ret);
 }
 
+template <typename T, typename... P, size_t... Is>
+void call_with_ptr_args_helper(T *p_instance, const std::function<void(T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, IndexSequence<Is...>) {
+	p_method(*p_instance, PtrToArg<P>::convert(p_args[Is])...);
+}
+
+template <typename T, typename... P, size_t... Is>
+void call_with_ptr_argsc_helper(T *p_instance, const std::function<void(const T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, IndexSequence<Is...>) {
+	p_method(*p_instance, PtrToArg<P>::convert(p_args[Is])...);
+}
+
+template <typename T, typename R, typename... P, size_t... Is>
+void call_with_ptr_args_ret_helper(T *p_instance, const std::function<R(T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, void *r_ret, IndexSequence<Is...>) {
+	PtrToArg<R>::encode(p_method(*p_instance, PtrToArg<P>::convert(p_args[Is])...), r_ret);
+}
+
+template <typename T, typename R, typename... P, size_t... Is>
+void call_with_ptr_args_retc_helper(T *p_instance, const std::function<R(const T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, void *r_ret, IndexSequence<Is...>) {
+	PtrToArg<R>::encode(p_method(*p_instance, PtrToArg<P>::convert(p_args[Is])...), r_ret);
+}
+
 template <typename T, typename... P>
 void call_with_ptr_args(T *p_instance, void (T::*p_method)(P...), const GDExtensionConstTypePtr *p_args, void * /*ret*/) {
 	call_with_ptr_args_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
@@ -225,6 +246,26 @@ void call_with_ptr_args(T *p_instance, R (T::*p_method)(P...), const GDExtension
 
 template <typename T, typename R, typename... P>
 void call_with_ptr_args(T *p_instance, R (T::*p_method)(P...) const, const GDExtensionConstTypePtr *p_args, void *r_ret) {
+	call_with_ptr_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename... P>
+void call_with_ptr_args(T *p_instance, const std::function<void(T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, void * /*ret*/) {
+	call_with_ptr_args_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename... P>
+void call_with_ptr_args(T *p_instance, const std::function<void(const T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, void * /*ret*/) {
+	call_with_ptr_argsc_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename R, typename... P>
+void call_with_ptr_args(T *p_instance, const std::function<R(T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, void *r_ret) {
+	call_with_ptr_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename R, typename... P>
+void call_with_ptr_args(T *p_instance, const std::function<R(const T &, P...)> &p_method, const GDExtensionConstTypePtr *p_args, void *r_ret) {
 	call_with_ptr_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
@@ -437,6 +478,248 @@ void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const 
 
 template <typename T, typename R, typename... P>
 void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const, const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
+
+	int32_t dvs = (int32_t)default_values.size();
+#ifdef DEBUG_ENABLED
+	if (missing > dvs) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	Variant args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; // Avoid zero sized array.
+	std::array<const Variant *, sizeof...(P)> argsp;
+	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
+		if (i < p_argcount) {
+			args[i] = Variant(p_args[i]);
+		} else {
+			args[i] = default_values[i - p_argcount + (dvs - missing)];
+		}
+		argsp[i] = &args[i];
+	}
+
+	call_with_variant_args_retc_helper(p_instance, p_method, argsp.data(), r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename... P, size_t... Is>
+void call_with_variant_args_helper(T *p_instance, const std::function<void(const T &, P...)> &p_method, const Variant **p_args, GDExtensionCallError &r_error, IndexSequence<Is...>) {
+	r_error.error = GDEXTENSION_CALL_OK;
+
+#ifdef DEBUG_METHODS_ENABLED
+	p_method(*p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+#else
+	p_method(*p_instance, VariantCaster<P>::cast(*p_args[Is])...);
+#endif
+	(void)(p_args); // Avoid warning.
+}
+
+template <typename T, typename... P, size_t... Is>
+void call_with_variant_argsc_helper(T *p_instance, const std::function<void(const T &, P...)> &p_method, const Variant **p_args, GDExtensionCallError &r_error, IndexSequence<Is...>) {
+	r_error.error = GDEXTENSION_CALL_OK;
+
+#ifdef DEBUG_METHODS_ENABLED
+	p_method(*p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+#else
+	p_method(*p_instance, VariantCaster<P>::cast(*p_args[Is])...);
+#endif
+	(void)(p_args); // Avoid warning.
+}
+
+template <typename T, typename R, typename... P, size_t... Is>
+void call_with_variant_args_ret_helper(T *p_instance, const std::function<R(T &, P...)> &p_method, const Variant **p_args, Variant &r_ret, GDExtensionCallError &r_error, IndexSequence<Is...>) {
+	r_error.error = GDEXTENSION_CALL_OK;
+
+#ifdef DEBUG_METHODS_ENABLED
+	r_ret = p_method(*p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+#else
+	r_ret = p_method(*p_instance, VariantCaster<P>::cast(*p_args[Is])...);
+#endif
+	(void)p_args; // Avoid warning.
+}
+
+template <typename T, typename R, typename... P, size_t... Is>
+void call_with_variant_args_retc_helper(T *p_instance, const std::function<R(const T &, P...)> &p_method, const Variant **p_args, Variant &r_ret, GDExtensionCallError &r_error, IndexSequence<Is...>) {
+	r_error.error = GDEXTENSION_CALL_OK;
+
+#ifdef DEBUG_METHODS_ENABLED
+	r_ret = p_method(*p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+#else
+	r_ret = p_method(*p_instance, VariantCaster<P>::cast(*p_args[Is])...);
+#endif
+	(void)p_args; // Avoid warning.
+}
+
+template <typename T, typename... P>
+void call_with_variant_args(T *p_instance, const std::function<void(T &, P...)> &p_method, const Variant **p_args, int p_argcount, GDExtensionCallError &r_error) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+
+	if ((size_t)p_argcount < sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+	call_with_variant_args_helper<T, P...>(p_instance, p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename R, typename... P>
+void call_with_variant_args_ret(T *p_instance, const std::function<R(T &, P...)> &p_method, const Variant **p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+
+	if ((size_t)p_argcount < sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+	call_with_variant_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename R, typename... P>
+void call_with_variant_args_retc(T *p_instance, const std::function<R(const T &, P...)> &p_method, const Variant **p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+
+	if ((size_t)p_argcount < sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+	call_with_variant_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename... P>
+void call_with_variant_args_dv(T *p_instance, const std::function<void(T &, P...)> &p_method, const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
+
+	int32_t dvs = (int32_t)default_values.size();
+#ifdef DEBUG_ENABLED
+	if (missing > dvs) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	Variant args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; // Avoid zero sized array.
+	std::array<const Variant *, sizeof...(P)> argsp;
+	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
+		if (i < p_argcount) {
+			args[i] = Variant(p_args[i]);
+		} else {
+			args[i] = default_values[i - p_argcount + (dvs - missing)];
+		}
+		argsp[i] = &args[i];
+	}
+
+	call_with_variant_args_helper(p_instance, p_method, argsp.data(), r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename... P>
+void call_with_variant_argsc_dv(T *p_instance, const std::function<void(const T &, P...)> &p_method, const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
+
+	int32_t dvs = (int32_t)default_values.size();
+#ifdef DEBUG_ENABLED
+	if (missing > dvs) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	Variant args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; // Avoid zero sized array.
+	std::array<const Variant *, sizeof...(P)> argsp;
+	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
+		if (i < p_argcount) {
+			args[i] = Variant(p_args[i]);
+		} else {
+			args[i] = default_values[i - p_argcount + (dvs - missing)];
+		}
+		argsp[i] = &args[i];
+	}
+
+	call_with_variant_argsc_helper(p_instance, p_method, argsp.data(), r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename R, typename... P>
+void call_with_variant_args_ret_dv(T *p_instance, const std::function<R(T &, P...)> &p_method, const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
+#ifdef DEBUG_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
+
+	int32_t dvs = (int32_t)default_values.size();
+#ifdef DEBUG_ENABLED
+	if (missing > dvs) {
+		r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = (int32_t)sizeof...(P);
+		return;
+	}
+#endif
+
+	Variant args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; // Avoid zero sized array.
+	std::array<const Variant *, sizeof...(P)> argsp;
+	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
+		if (i < p_argcount) {
+			args[i] = Variant(p_args[i]);
+		} else {
+			args[i] = default_values[i - p_argcount + (dvs - missing)];
+		}
+		argsp[i] = &args[i];
+	}
+
+	call_with_variant_args_ret_helper(p_instance, p_method, argsp.data(), r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <typename T, typename R, typename... P>
+void call_with_variant_args_retc_dv(T *p_instance, const std::function<R(const T &, P...)> &p_method, const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -42,6 +42,36 @@
 
 namespace godot {
 
+template <std::size_t N, typename... Ts>
+using NthType = typename std::tuple_element_t<N, std::tuple<Ts...>>;
+
+template <typename T>
+struct RemoveClass {};
+
+template <typename C, typename R, typename... P>
+struct RemoveClass<R (C::*)(P...)> {
+	using type = R(P...);
+};
+
+template <typename C, typename R, typename... P>
+struct RemoveClass<R (C::*)(P...) const> {
+	using type = R(P...);
+};
+
+template <typename F>
+struct StripFunctionObject {
+	using type = typename RemoveClass<decltype(&F::operator())>::type;
+};
+
+template <typename Invocable, typename F = std::remove_reference_t<Invocable>>
+using FunctionSignature = std::conditional_t<
+		std::is_function_v<F>,
+		F,
+		typename std::conditional_t<
+				std::is_pointer_v<F> || std::is_member_pointer_v<F>,
+				std::remove_pointer<F>,
+				StripFunctionObject<F>>::type>;
+
 class MethodBind {
 	uint32_t hint_flags = METHOD_FLAGS_DEFAULT;
 	StringName name;
@@ -592,6 +622,265 @@ MethodBind *create_method_bind(R (T::*p_method)(P...) const) {
 #endif // TYPED_METHOD_BIND
 	a->set_instance_class(T::get_class_static());
 	return a;
+}
+
+// CALLABLE OBJECTS
+
+// No return, not const.
+
+template <typename T, typename... P>
+class MethodBindTL : public MethodBind {
+	std::function<void(T &, P...)> method;
+
+protected:
+// GCC raises warnings in the case P = {} as the comparison is always false...
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#endif
+	virtual GDExtensionVariantType gen_argument_type(int p_arg) const {
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			return call_get_argument_type<P...>(p_arg);
+		} else {
+			return GDEXTENSION_VARIANT_TYPE_NIL;
+		}
+	}
+
+	virtual PropertyInfo gen_argument_type_info(int p_arg) const {
+		PropertyInfo pi;
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			call_get_argument_type_info<P...>(p_arg, pi);
+		} else {
+			pi = PropertyInfo();
+		}
+		return pi;
+	}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+public:
+	virtual GDExtensionClassMethodArgumentMetadata get_argument_metadata(int p_argument) const {
+		return call_get_argument_metadata<P...>(p_argument);
+	}
+
+	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionCallError &r_error) const {
+		call_with_variant_args_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, r_error, get_default_arguments());
+		return Variant();
+	}
+	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret) const {
+		call_with_ptr_args<T, P...>(static_cast<T *>(p_instance), method, p_args, nullptr);
+	}
+
+	MethodBindTL(std::function<void(T &, P...)> &&p_method) {
+		method = p_method;
+		_generate_argument_types(sizeof...(P));
+		set_argument_count(sizeof...(P));
+	}
+};
+
+template <typename F, typename T, typename... P>
+MethodBind *create_method_bind(F &&p_method, void (*)(T &, P...)) {
+	MethodBind *a = memnew((MethodBindTL<T, P...>)(std::function<void(T &, P...)>(p_method)));
+	a->set_instance_class(T::get_class_static());
+	return a;
+}
+
+// No return, const.
+
+template <typename T, typename... P>
+class MethodBindTLC : public MethodBind {
+	std::function<void(const T &, P...)> method;
+
+protected:
+// GCC raises warnings in the case P = {} as the comparison is always false...
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#endif
+	virtual GDExtensionVariantType gen_argument_type(int p_arg) const {
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			return call_get_argument_type<P...>(p_arg);
+		} else {
+			return GDEXTENSION_VARIANT_TYPE_NIL;
+		}
+	}
+
+	virtual PropertyInfo gen_argument_type_info(int p_arg) const {
+		PropertyInfo pi;
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			call_get_argument_type_info<P...>(p_arg, pi);
+		} else {
+			pi = PropertyInfo();
+		}
+		return pi;
+	}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+public:
+	virtual GDExtensionClassMethodArgumentMetadata get_argument_metadata(int p_argument) const {
+		return call_get_argument_metadata<P...>(p_argument);
+	}
+
+	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionCallError &r_error) const {
+		call_with_variant_argsc_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, r_error, get_default_arguments());
+		return Variant();
+	}
+	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret) const {
+		call_with_ptr_args<T, P...>(static_cast<T *>(p_instance), method, p_args, nullptr);
+	}
+
+	MethodBindTLC(std::function<void(const T &, P...)> &&p_method) {
+		method = p_method;
+		_generate_argument_types(sizeof...(P));
+		set_argument_count(sizeof...(P));
+	}
+};
+
+template <typename F, typename T, typename... P>
+MethodBind *create_method_bind(F &&p_method, void (*)(const T &, P...)) {
+	MethodBind *a = memnew((MethodBindTLC<T, P...>)(std::function<void(const T &, P...)>(p_method)));
+	a->set_instance_class(T::get_class_static());
+	return a;
+}
+
+// Return, not const.
+
+template <typename T, typename R, typename... P>
+class MethodBindTLR : public MethodBind {
+	std::function<R(T &, P...)> method;
+
+protected:
+// GCC raises warnings in the case P = {} as the comparison is always false...
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#endif
+	virtual GDExtensionVariantType gen_argument_type(int p_arg) const {
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			return call_get_argument_type<P...>(p_arg);
+		} else {
+			return GDExtensionVariantType(GetTypeInfo<R>::VARIANT_TYPE);
+		}
+	}
+
+	virtual PropertyInfo gen_argument_type_info(int p_arg) const {
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			PropertyInfo pi;
+			call_get_argument_type_info<P...>(p_arg, pi);
+			return pi;
+		} else {
+			return GetTypeInfo<R>::get_class_info();
+		}
+	}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+public:
+	virtual GDExtensionClassMethodArgumentMetadata get_argument_metadata(int p_argument) const {
+		if (p_argument >= 0) {
+			return call_get_argument_metadata<P...>(p_argument);
+		} else {
+			return GetTypeInfo<R>::METADATA;
+		}
+	}
+
+	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionCallError &r_error) const {
+		Variant ret;
+		call_with_variant_args_ret_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, ret, r_error, get_default_arguments());
+		return ret;
+	}
+	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret) const {
+		call_with_ptr_args<T, R, P...>(static_cast<T *>(p_instance), method, p_args, r_ret);
+	}
+
+	MethodBindTLR(std::function<R(T &, P...)> &&p_method) {
+		method = p_method;
+		_generate_argument_types(sizeof...(P));
+		set_argument_count(sizeof...(P));
+		_set_returns(true);
+	}
+};
+
+template <typename F, typename T, typename R, typename... P>
+std::enable_if_t<!std::is_same_v<R, void>, MethodBind *> create_method_bind(F &&p_method, R (*)(T &, P...)) {
+	MethodBind *a = memnew((MethodBindTLR<T, R, P...>)(std::function<R(T &, P...)>(p_method)));
+	a->set_instance_class(T::get_class_static());
+	return a;
+}
+
+// Return, const.
+
+template <typename T, typename R, typename... P>
+class MethodBindTLRC : public MethodBind {
+	std::function<R(const T &, P...)> method;
+
+protected:
+// GCC raises warnings in the case P = {} as the comparison is always false...
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#endif
+	virtual GDExtensionVariantType gen_argument_type(int p_arg) const {
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			return call_get_argument_type<P...>(p_arg);
+		} else {
+			return GDExtensionVariantType(GetTypeInfo<R>::VARIANT_TYPE);
+		}
+	}
+
+	virtual PropertyInfo gen_argument_type_info(int p_arg) const {
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			PropertyInfo pi;
+			call_get_argument_type_info<P...>(p_arg, pi);
+			return pi;
+		} else {
+			return GetTypeInfo<R>::get_class_info();
+		}
+	}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+public:
+	virtual GDExtensionClassMethodArgumentMetadata get_argument_metadata(int p_argument) const {
+		if (p_argument >= 0) {
+			return call_get_argument_metadata<P...>(p_argument);
+		} else {
+			return GetTypeInfo<R>::METADATA;
+		}
+	}
+
+	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionCallError &r_error) const {
+		Variant ret;
+		call_with_variant_args_retc_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, ret, r_error, get_default_arguments());
+		return ret;
+	}
+	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret) const {
+		call_with_ptr_args<T, R, P...>(static_cast<T *>(p_instance), method, p_args, r_ret);
+	}
+
+	MethodBindTLRC(std::function<R(const T &, P...)> &&p_method) {
+		method = p_method;
+		_generate_argument_types(sizeof...(P));
+		set_argument_count(sizeof...(P));
+		_set_returns(true);
+	}
+};
+
+template <typename F, typename T, typename R, typename... P>
+std::enable_if_t<!std::is_same_v<R, void>, MethodBind *> create_method_bind(F &&p_method, R (*)(const T &, P...)) {
+	MethodBind *a = memnew((MethodBindTLRC<T, R, P...>)(std::function<R(const T &, P...)>(p_method)));
+	a->set_instance_class(T::get_class_static());
+	return a;
+}
+
+template <typename F>
+MethodBind *create_method_bind(F &&p_method) {
+	return create_method_bind(std::forward<F>(p_method), (FunctionSignature<F> *)nullptr);
 }
 
 // STATIC BINDS


### PR DESCRIPTION
This PR allows API users to bind lambdas as member methods in classes for the bindings, much like Python language C++ bindings such as pybind11. This is a draft implementation of this godotengine/godot-proposals#14485 proposal.

Sample usage.

```cpp
void Sample::_bind_methods() {
  ClassDB::bind_method(godot::D_METHOD("get_test"), [](const Sample &s) { return s.test; });
  ClassDB::bind_method(godot::D_METHOD("set_test"), [](Sample &s, const String &test) { s.test = test; });
}
```

See godotengine/godot#117541 for the engine implementation counterpart.
