### PR TITLE
Custom type converters for method binding and variant casting

### DIFF
--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -113,6 +113,62 @@ struct PtrToArg {};
 		}                                                                     \
 	}
 
+#define MAKE_PTRARG_CONVERTER(m_type, m_conv, m_to, m_from)            \
+	template <>                                                        \
+	struct PtrToArg<m_type> {                                          \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
+			return m_to(*reinterpret_cast<const m_conv *>(p_ptr));     \
+		}                                                              \
+		typedef m_conv EncodeT;                                        \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
+			*reinterpret_cast<m_conv *>(p_ptr) = m_from(p_val);        \
+		}                                                              \
+		_FORCE_INLINE_ static m_conv encode_arg(m_type p_val) {        \
+			return m_from(p_val);                                      \
+		}                                                              \
+	};                                                                 \
+	template <>                                                        \
+	struct PtrToArg<const m_type &> {                                  \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
+			return m_to(*reinterpret_cast<const m_conv *>(p_ptr));     \
+		}                                                              \
+		typedef m_conv EncodeT;                                        \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
+			*reinterpret_cast<m_conv *>(p_ptr) = m_from(p_val);        \
+		}                                                              \
+		_FORCE_INLINE_ static m_conv encode_arg(m_type p_val) {        \
+			return m_from(p_val);                                      \
+		}                                                              \
+	}
+
+#define MAKE_PTRARG_CONVERTER_BY_REFERENCE(m_type, m_conv, m_to, m_from)      \
+	template <>                                                               \
+	struct PtrToArg<m_type> {                                                 \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+			return m_to(*reinterpret_cast<const m_conv *>(p_ptr));            \
+		}                                                                     \
+		typedef m_conv EncodeT;                                               \
+		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
+			*reinterpret_cast<m_type *>(p_ptr) = m_from(p_val);               \
+		}                                                                     \
+		_FORCE_INLINE_ static m_conv encode_arg(const m_type &p_val) {        \
+			return m_from(p_val);                                             \
+		}                                                                     \
+	};                                                                        \
+	template <>                                                               \
+	struct PtrToArg<const m_type &> {                                         \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+			return m_to(*reinterpret_cast<const m_conv *>(p_ptr));            \
+		}                                                                     \
+		typedef m_conv EncodeT;                                               \
+		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
+			*reinterpret_cast<m_type *>(p_ptr) = m_from(p_val);               \
+		}                                                                     \
+		_FORCE_INLINE_ static m_conv encode_arg(const m_type &p_val) {        \
+			return m_from(p_val);                                             \
+		}                                                                     \
+	}
+
 MAKE_PTRARGCONV(bool, uint8_t);
 // Integer types.
 MAKE_PTRARGCONV(uint8_t, int64_t);

--- a/include/godot_cpp/variant/converter.hpp
+++ b/include/godot_cpp/variant/converter.hpp
@@ -1,0 +1,80 @@
+/**************************************************************************/
+/*  converter.hpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/core/method_ptrcall.hpp>
+#include <godot_cpp/core/type_info.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+#include <gdextension_interface.h>
+
+#define GD_REGISTER_CONVERSION(m_type, m_conv, m_to, m_from, m_var_type)      \
+	namespace godot {                                                         \
+	template <>                                                               \
+	struct VariantCaster<m_type> {                                            \
+		_FORCE_INLINE_ static m_type cast(const Variant &p_variant) {         \
+			return m_to(p_variant);                                           \
+		}                                                                     \
+		template <>                                                           \
+		struct VariantCaster<m_type &> {                                      \
+			_FORCE_INLINE_ static m_type cast(const Variant &p_variant) {     \
+				return m_to(p_variant);                                       \
+			}                                                                 \
+			template <>                                                       \
+			struct VariantCaster<const m_type &> {                            \
+				_FORCE_INLINE_ static m_type cast(const Variant &p_variant) { \
+					return m_to(p_variant);                                   \
+				}                                                             \
+				MAKE_TYPE_INFO(m_type, m_var_type)                            \
+				MAKE_PTRARG_CONVERTER(m_type, m_conv, m_to, m_from);          \
+			}
+
+#define GD_REGISTER_CONVERSION_BY_REFERENCE(m_type, m_conv, m_to, m_from, m_var_type) \
+	namespace godot {                                                                 \
+	template <>                                                                       \
+	struct VariantCaster<m_type> {                                                    \
+		_FORCE_INLINE_ static m_type cast(const Variant &p_variant) {                 \
+			return m_to(p_variant);                                                   \
+		}                                                                             \
+		template <>                                                                   \
+		struct VariantCaster<m_type &> {                                              \
+			_FORCE_INLINE_ static m_type cast(const Variant &p_variant) {             \
+				return m_to(p_variant);                                               \
+			}                                                                         \
+			template <>                                                               \
+			struct VariantCaster<const m_type &> {                                    \
+				_FORCE_INLINE_ static m_type cast(const Variant &p_variant) {         \
+					return m_to(p_variant);                                           \
+				}                                                                     \
+				MAKE_TYPE_INFO(m_type, m_var_type)                                    \
+				MAKE_PTRARG_CONVERTER_BY_REFERENCE(m_type, m_conv, m_to, m_from);     \
+			}

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -215,6 +215,9 @@ public:
 	Variant(const PackedVector3Array &v);
 	Variant(const PackedColorArray &v);
 	Variant(const PackedVector4Array &v);
+	template <typename T, typename = std::void_t<decltype(PtrToArg<T>::encode_arg(std::declval<T>()))>>
+	Variant(T v) :
+			Variant(PtrToArg<T>::encode_arg(v)) {}
 	~Variant();
 
 	operator bool() const;


### PR DESCRIPTION
With this API users can bind methods which have types in their signature that are not supported by default in the Godot C++ bindings. Closes godotengine/godot-proposals#14507 proposal.

Sample usage.

```cpp
// Extracted from one of the headers of a library.

struct Vector {
  float x;
  float y;
  float z;
};

// In another source file. Define these converters so that `Vector` can be used in method signatures.

_FORCE_INLINE_ godot::Vector3 vector_to_vector3(const Vector &v) {
  return godot::Vector3(v.x, v.y, v.z);
}

_FORCE_INLINE_ Vector vector_from_vector3(const godot::Vector3 &v) {
  return Vector(v.x, v.y, v.z);
}

// This registers the converters so that they can be used in method bindings, variants, etc.
// We pass both `vector_to_vector3` and `vector_from_vector3` here.

GD_REGISTER_CONVERSION(Vector, godot::Vector3, vector_to_vector3, vector_from_vector3);

// In a source file which has a wrapper for a type from a library, in this case with the `Entity` class.
// Notice that we use the library types and that the converters are called elsewhere.

Vector Entity::get_position() const {
  return wrapped.position();
}

void Entity::set_position(const Vector &v) {
  wrapped.position() = v;
}

void Entity::_bind_methods() {
  godot::ClassDB::bind_method(godot::D_METHOD("get_position"), &Entity::get_position);
  godot::ClassDB::bind_method(godot::D_METHOD("set_position", "position"), &Entity::set_position);
}
```
