### PR TITLE
Fix `StringName` leaks when app is run with `--verbose`

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -157,7 +157,7 @@ void free_c_property_list(GDExtensionPropertyInfo *plist);
 
 typedef void (*EngineClassRegistrationCallback)();
 void add_engine_class_registration_callback(EngineClassRegistrationCallback p_callback);
-void register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+void register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks, void (*p_destruct_class_static)());
 void register_engine_classes();
 
 template <typename T>
@@ -167,7 +167,7 @@ struct EngineClassRegistration {
 	}
 
 	static void callback() {
-		register_engine_class(T::get_class_static(), &T::_gde_binding_callbacks);
+		register_engine_class(T::get_class_static(), &T::_gde_binding_callbacks, T::destruct_class_static);
 	}
 };
 
@@ -253,7 +253,16 @@ public:                                                                         
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static const ::godot::StringName &get_class_static() {                                                                                                                             \
-		static const ::godot::StringName string_name = ::godot::StringName(U## #m_class);                                                                                              \
+		return get_class_static_nonconst();                                                                                                                                            \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void destruct_class_static() {                                                                                                                                              \
+		::godot::StringName &class_static = get_class_static_nonconst();                                                                                                               \
+		class_static = StringName();                                                                                                                                                   \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static ::godot::StringName &get_class_static_nonconst() {                                                                                                                          \
+		static ::godot::StringName string_name = ::godot::StringName(U## #m_class);                                                                                                    \
 		return string_name;                                                                                                                                                            \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
@@ -466,7 +475,16 @@ public:                                                                         
 	static void initialize_class() {}                                                                                                                                                  \
                                                                                                                                                                                        \
 	static const ::godot::StringName &get_class_static() {                                                                                                                             \
-		static const ::godot::StringName string_name = ::godot::StringName(#m_alias_for);                                                                                              \
+		return get_class_static_nonconst();                                                                                                                                            \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void destruct_class_static() {                                                                                                                                              \
+		::godot::StringName &class_static = get_class_static_nonconst();                                                                                                               \
+		class_static = StringName();                                                                                                                                                   \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static ::godot::StringName &get_class_static_nonconst() {                                                                                                                          \
+		static ::godot::StringName string_name = ::godot::StringName(#m_alias_for);                                                                                                    \
 		return string_name;                                                                                                                                                            \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -98,6 +98,7 @@ private:
 	// This may only contain custom classes, not Godot classes
 	static HashMap<StringName, ClassInfo> classes;
 	static AHashMap<StringName, const GDExtensionInstanceBindingCallbacks *> instance_binding_callbacks;
+	static std::set<void (*)()> instance_binding_destruct_class_static_callbacks;
 	// Used to remember the custom class registration order.
 	static LocalVector<StringName> class_register_order;
 	static AHashMap<StringName, Object *> engine_singletons;
@@ -161,8 +162,9 @@ public:
 	template <typename T>
 	static void register_runtime_class();
 
-	_FORCE_INLINE_ static void _register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
+	_FORCE_INLINE_ static void _register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks, void (*p_destruct_class_static)()) {
 		instance_binding_callbacks[p_name] = p_callbacks;
+		instance_binding_destruct_class_static_callbacks.insert(p_destruct_class_static);
 	}
 
 	static void _editor_get_classes_used_callback(GDExtensionTypePtr p_packed_string_array);
@@ -240,6 +242,7 @@ void ClassDB::_register_class(bool p_virtual, bool p_exposed, bool p_runtime) {
 	static_assert(!FunctionsAreSame<T::self_type::_bind_methods, T::parent_type::_bind_methods>::value, "Class must declare 'static void _bind_methods'.");
 	static_assert(!std::is_abstract_v<T> || is_abstract, "Class is abstract, please use GDREGISTER_ABSTRACT_CLASS.");
 	instance_binding_callbacks[T::get_class_static()] = &T::_gde_binding_callbacks;
+	instance_binding_destruct_class_static_callbacks.insert(T::destruct_class_static);
 
 	// Register this class within our plugin
 	ClassInfo cl;

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -153,8 +153,8 @@ void add_engine_class_registration_callback(EngineClassRegistrationCallback p_ca
 	get_engine_class_registration_callbacks().push_back(p_callback);
 }
 
-void register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
-	ClassDB::_register_engine_class(p_name, p_callbacks);
+void register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks, void (*p_destruct_class_static)()) {
+	ClassDB::_register_engine_class(p_name, p_callbacks, p_destruct_class_static);
 }
 
 void register_engine_classes() {

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -40,6 +40,7 @@ namespace godot {
 
 HashMap<StringName, ClassDB::ClassInfo> ClassDB::classes;
 AHashMap<StringName, const GDExtensionInstanceBindingCallbacks *> ClassDB::instance_binding_callbacks;
+std::set<void (*)()> ClassDB::instance_binding_destruct_class_static_callbacks;
 LocalVector<StringName> ClassDB::class_register_order;
 AHashMap<StringName, Object *> ClassDB::engine_singletons;
 std::mutex ClassDB::engine_singletons_mutex;
@@ -458,6 +459,13 @@ void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
 		for (const Object *i : singleton_objects) {
 			::godot::gdextension_interface::object_free_instance_binding((*i)._owner, ::godot::gdextension_interface::token);
 		}
+
+		instance_binding_callbacks.clear();
+
+		for (void (*destruct_class_static)() : instance_binding_destruct_class_static_callbacks) {
+			destruct_class_static();
+		}
+		instance_binding_destruct_class_static_callbacks.clear();
 	}
 }
 


### PR DESCRIPTION
Repro:

1: Download the latest stable release of the Godot editor for Linux to the `~/Downloads` directory and extract it
2:
```
git clone -b master --single-branch https://github.com/GodotVR/godot_openxr_vendors
cd godot_openxr_vendors
git submodule update --init
./gradlew buildPlugin
```
3: Open-then-close the app once in the editor
4:
``` 
~/Downloads/Godot_v4.6.1-stable_linux/Godot_v4.6.1-stable_linux.x86_64 --verbose --quit --headless --path samples/meta-composition-layers-sample
```
5: Notice there are many leaked StringNames. In my test I got 189 leaked StringNames

This PR is rebased on [tag 10.0.0-rc1](https://github.com/godotengine/godot-cpp/tree/58d1de720b8ffe9f8ffcdfe3a85148582cfd2e74) since I couldn't compile with latest in the godot_openxr_vendors repo.
I'm also expecting that `std::set` will need to be replaced with `HashSet`, though doing it now produces compilation failures.