### PR TITLE
Align MethodInfo equality check with engine

### DIFF
--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -70,7 +70,7 @@ struct MethodInfo {
 	GDExtensionClassMethodArgumentMetadata return_val_metadata;
 	LocalVector<GDExtensionClassMethodArgumentMetadata> arguments_metadata;
 
-	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id; }
+	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id && name == p_method.name; }
 	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }
 
 	operator Dictionary() const;


### PR DESCRIPTION
Fixes the `MethodInfo` equality `operator==` check to use the `name` like in the engine.

I came across this because I was using some similar code to the engine that does:
```cpp
if (!(info == MethodInfo())) {
  /* do stuff */
}
```
And I could not understand why a full MethodInfo would not trigger the if-block. :sob: 