### PR TITLE
FIX:	separated situation of building/installing on target_include_directories on cmake

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -371,7 +371,9 @@ function(godotcpp_generate)
     target_include_directories(
         godot-cpp
         ${GODOTCPP_SYSTEM_HEADERS_ATTRIBUTE}
-        PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/gen/include
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/gen/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
 
     # gersemi: off


### PR DESCRIPTION
Basically it is not about "making export enabled". I am talking about a simple policy that included directories(for headers) must not be children of where root CMakeLists.txt is when being exported.  
This check is hard-coded behaviour not to confuse the system, since installation in this context stands for a situation that several wanted files(headers, library files, etc) should move to another path then original.

Since we are not making any exportation of godot-cpp itself, you do not need to understand those to understand this request I am writing.

For detail, my stupid macro generator interface library is marked (could be installed) refers to godot-cpp, which expects godot-cpp to separate the directory to include.

Reading first sentence of [this paragraph](https://cmake.org/cmake/help/latest/command/target_include_directories.html#creating-relocatable-packages) would help in this case.