### PR TITLE
Update `gdextension_interface.json` and `extension_api.json` for Godot 4.7-beta1

### DIFF
--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -29,7 +29,18 @@ jobs:
             artifact-name: godot-cpp-linux-glibc2.27-x86_64-release
             artifact-path: bin/libgodot-cpp.linux.template_release.x86_64.a
             run-tests: true
+            api-version: 4.7
             cache-name: linux-x86_64
+
+          - name: 🐧 Linux (GCC) for Godot 4.6
+            os: ubuntu-22.04
+            platform: linux
+            artifact-name: godot-cpp-linux-glibc2.27-x86_64-release-godot45
+            artifact-path: bin/libgodot-cpp.linux.template_release.x86_64.a
+            run-tests: true
+            api-version: 4.6
+            godot-test-versions: "4.6-stable"
+            cache-name: linux-x86_64-godot45
 
           - name: 🐧 Linux (GCC) for Godot 4.5
             os: ubuntu-22.04
@@ -38,7 +49,7 @@ jobs:
             artifact-path: bin/libgodot-cpp.linux.template_release.x86_64.a
             run-tests: true
             api-version: 4.5
-            godot-test-versions: "4.5-stable"
+            godot-test-versions: "4.5-stable 4.6-stable"
             cache-name: linux-x86_64-godot45
 
           - name: 🐧 Linux (GCC) for Godot 4.4
@@ -48,7 +59,7 @@ jobs:
             artifact-path: bin/libgodot-cpp.linux.template_release.x86_64.a
             run-tests: true
             api-version: 4.4
-            godot-test-versions: "4.4-stable 4.5-stable"
+            godot-test-versions: "4.4-stable 4.5-stable 4.6-stable"
             cache-name: linux-x86_64-godot44
 
           - name: 🐧 Linux (GCC) for Godot 4.3
@@ -58,7 +69,7 @@ jobs:
             artifact-path: bin/libgodot-cpp.linux.template_release.x86_64.a
             run-tests: true
             api-version: 4.3
-            godot-test-versions: "4.3-stable 4.4-stable 4.5-stable"
+            godot-test-versions: "4.3-stable 4.4-stable 4.5-stable 4.6-stable"
             cache-name: linux-x86_64-godot43
 
           - name: 🏁 Windows (x86_64, MSVC)

--- a/gdextension/gdextension_interface.json
+++ b/gdextension/gdextension_interface.json
@@ -986,7 +986,11 @@
                     "name": "p_list",
                     "type": "const GDExtensionPropertyInfo*"
                 }
-            ]
+            ],
+            "deprecated": {
+                "since": "4.3",
+                "replace_with": "GDExtensionClassFreePropertyList2"
+            }
         },
         {
             "name": "GDExtensionClassFreePropertyList2",
@@ -1164,7 +1168,15 @@
                     "name": "p_class_userdata",
                     "type": "void*"
                 }
-            ]
+            ],
+            "description": [
+                "Called to construct an instance of the class.",
+                "For classes descending from RefCounted, the reference count should be zero."
+            ],
+            "deprecated": {
+                "since": "4.4",
+                "replace_with": "GDExtensionClassCreateInstance3"
+            }
         },
         {
             "name": "GDExtensionClassCreateInstance2",
@@ -1181,6 +1193,35 @@
                     "name": "p_notify_postinitialize",
                     "type": "GDExtensionBool"
                 }
+            ],
+            "description": [
+                "Called to construct an instance of the class.",
+                "For classes descending from RefCounted, the reference count should be zero."
+            ],
+            "deprecated": {
+                "since": "4.7",
+                "replace_with": "GDExtensionClassCreateInstance3"
+            }
+        },
+        {
+            "name": "GDExtensionClassCreateInstance3",
+            "kind": "function",
+            "return_value": {
+                "type": "GDExtensionObjectPtr"
+            },
+            "arguments": [
+                {
+                    "name": "p_class_userdata",
+                    "type": "void*"
+                },
+                {
+                    "name": "p_notify_postinitialize",
+                    "type": "GDExtensionBool"
+                }
+            ],
+            "description": [
+                "Called to construct an instance of the class.",
+                "For classes descending from RefCounted, the reference count should already be incremented by 1."
             ]
         },
         {
@@ -1229,7 +1270,11 @@
                     "name": "p_name",
                     "type": "GDExtensionConstStringNamePtr"
                 }
-            ]
+            ],
+            "deprecated": {
+                "since": "4.4",
+                "replace_with": "GDExtensionClassGetVirtual2"
+            }
         },
         {
             "name": "GDExtensionClassGetVirtual2",
@@ -1267,7 +1312,11 @@
                     "name": "p_name",
                     "type": "GDExtensionConstStringNamePtr"
                 }
-            ]
+            ],
+            "deprecated": {
+                "since": "4.4",
+                "replace_with": "GDExtensionClassGetVirtualCallData2"
+            }
         },
         {
             "name": "GDExtensionClassGetVirtualCallData2",
@@ -1372,7 +1421,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1403,7 +1452,7 @@
             ],
             "deprecated": {
                 "since": "4.2",
-                "replace_with": "GDExtensionClassCreationInfo4"
+                "replace_with": "GDExtensionClassCreationInfo6"
             }
         },
         {
@@ -1470,7 +1519,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1524,7 +1573,7 @@
             ],
             "deprecated": {
                 "since": "4.3",
-                "replace_with": "GDExtensionClassCreationInfo4"
+                "replace_with": "GDExtensionClassCreationInfo6"
             }
         },
         {
@@ -1595,7 +1644,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1649,7 +1698,7 @@
             ],
             "deprecated": {
                 "since": "4.4",
-                "replace_with": "GDExtensionClassCreationInfo4"
+                "replace_with": "GDExtensionClassCreationInfo6"
             }
         },
         {
@@ -1724,7 +1773,141 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance2",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
+                    ]
+                },
+                {
+                    "name": "free_instance_func",
+                    "type": "GDExtensionClassFreeInstance",
+                    "description": [
+                        "Destructor; mandatory."
+                    ]
+                },
+                {
+                    "name": "recreate_instance_func",
+                    "type": "GDExtensionClassRecreateInstance"
+                },
+                {
+                    "name": "get_virtual_func",
+                    "type": "GDExtensionClassGetVirtual2",
+                    "description": [
+                        "Queries a virtual function by name and returns a callback to invoke the requested virtual function."
+                    ]
+                },
+                {
+                    "name": "get_virtual_call_data_func",
+                    "type": "GDExtensionClassGetVirtualCallData2",
+                    "description": [
+                        "Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that",
+                        "need or benefit from extra data when calling virtual functions.",
+                        "Returns user data that will be passed to `call_virtual_with_data_func`.",
+                        "Returning `NULL` from this function signals to Godot that the virtual function is not overridden.",
+                        "Data returned from this function should be managed by the extension and must be valid until the extension is deinitialized.",
+                        "You should supply either `get_virtual_func`, or `get_virtual_call_data_func` with `call_virtual_with_data_func`."
+                    ]
+                },
+                {
+                    "name": "call_virtual_with_data_func",
+                    "type": "GDExtensionClassCallVirtualWithData",
+                    "description": [
+                        "Used to call virtual functions when `get_virtual_call_data_func` is not null."
+                    ]
+                },
+                {
+                    "name": "class_userdata",
+                    "type": "void*",
+                    "description": [
+                        "Per-class user data, later accessible in instance bindings."
+                    ]
+                }
+            ],
+            "deprecated": {
+                "since": "4.5",
+                "replace_with": "GDExtensionClassCreationInfo6"
+            }
+        },
+        {
+            "name": "GDExtensionClassCreationInfo5",
+            "kind": "alias",
+            "type": "GDExtensionClassCreationInfo4",
+            "deprecated": {
+                "since": "4.7",
+                "replace_with": "GDExtensionClassCreationInfo6"
+            }
+        },
+        {
+            "name": "GDExtensionClassCreationInfo6",
+            "kind": "struct",
+            "members": [
+                {
+                    "name": "is_virtual",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "is_abstract",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "is_exposed",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "is_runtime",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "icon_path",
+                    "type": "GDExtensionConstStringPtr"
+                },
+                {
+                    "name": "set_func",
+                    "type": "GDExtensionClassSet"
+                },
+                {
+                    "name": "get_func",
+                    "type": "GDExtensionClassGet"
+                },
+                {
+                    "name": "get_property_list_func",
+                    "type": "GDExtensionClassGetPropertyList"
+                },
+                {
+                    "name": "free_property_list_func",
+                    "type": "GDExtensionClassFreePropertyList2"
+                },
+                {
+                    "name": "property_can_revert_func",
+                    "type": "GDExtensionClassPropertyCanRevert"
+                },
+                {
+                    "name": "property_get_revert_func",
+                    "type": "GDExtensionClassPropertyGetRevert"
+                },
+                {
+                    "name": "validate_property_func",
+                    "type": "GDExtensionClassValidateProperty"
+                },
+                {
+                    "name": "notification_func",
+                    "type": "GDExtensionClassNotification2"
+                },
+                {
+                    "name": "to_string_func",
+                    "type": "GDExtensionClassToString"
+                },
+                {
+                    "name": "reference_func",
+                    "type": "GDExtensionClassReference"
+                },
+                {
+                    "name": "unreference_func",
+                    "type": "GDExtensionClassUnreference"
+                },
+                {
+                    "name": "create_instance_func",
+                    "type": "GDExtensionClassCreateInstance3",
+                    "description": [
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1772,11 +1955,6 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "GDExtensionClassCreationInfo5",
-            "kind": "alias",
-            "type": "GDExtensionClassCreationInfo4"
         },
         {
             "name": "GDExtensionClassLibraryPtr",
@@ -3375,7 +3553,11 @@
                     "name": "string",
                     "type": "const char*"
                 }
-            ]
+            ],
+            "deprecated": {
+                "since": "4.5",
+                "replace_with": "GDExtensionGodotVersion2"
+            }
         },
         {
             "name": "GDExtensionGodotVersion2",
@@ -4979,6 +5161,28 @@
             "since": "4.1"
         },
         {
+            "name": "variant_get_type_by_name",
+            "return_value": {
+                "type": "GDExtensionVariantType",
+                "description": [
+                    "The variant type for the given name; otherwise VARIANT_MAX if name is invalid."
+                ]
+            },
+            "arguments": [
+                {
+                    "name": "p_type_name",
+                    "type": "GDExtensionConstStringPtr",
+                    "description": [
+                        "The variant type name."
+                    ]
+                }
+            ],
+            "description": [
+                "Gets the Variant type by name."
+            ],
+            "since": "4.7"
+        },
+        {
             "name": "variant_can_convert",
             "return_value": {
                 "type": "GDExtensionBool",
@@ -5859,7 +6063,7 @@
             "return_value": {
                 "type": "GDExtensionInt",
                 "description": [
-                    "The resulting encoded string length in characters (not bytes), not including a null terminator."
+                    "The resulting encoded string length in characters, not including a null terminator. Characters that cannot be converted to Latin-1 are replaced with a space."
                 ]
             },
             "arguments": [
@@ -5896,7 +6100,7 @@
             "return_value": {
                 "type": "GDExtensionInt",
                 "description": [
-                    "The resulting encoded string length in characters (not bytes), not including a null terminator."
+                    "The resulting encoded string length in bytes (not characters), not including a null terminator."
                 ]
             },
             "arguments": [
@@ -5933,7 +6137,7 @@
             "return_value": {
                 "type": "GDExtensionInt",
                 "description": [
-                    "The resulting encoded string length in characters (not bytes), not including a null terminator."
+                    "The resulting encoded string length in 16-bit code units (not bytes or characters), not including a null terminator."
                 ]
             },
             "arguments": [
@@ -6007,7 +6211,7 @@
             "return_value": {
                 "type": "GDExtensionInt",
                 "description": [
-                    "The resulting encoded string length in characters (not bytes), not including a null terminator."
+                    "The resulting encoded string length in characters (for UTF-32) or 16-bit code units (for UTF-16), depending on the wchar_t representation. Does not include a null terminator."
                 ]
             },
             "arguments": [
@@ -8242,7 +8446,7 @@
             "since": "4.1",
             "deprecated": {
                 "since": "4.4",
-                "replace_with": "classdb_construct_object2"
+                "replace_with": "classdb_construct_object3"
             }
         },
         {
@@ -8268,7 +8472,37 @@
                 "",
                 "\"NOTIFICATION_POSTINITIALIZE\" must be sent after construction."
             ],
-            "since": "4.4"
+            "since": "4.4",
+            "deprecated": {
+                "since": "4.7",
+                "replace_with": "classdb_construct_object3"
+            }
+        },
+        {
+            "name": "classdb_construct_object3",
+            "return_value": {
+                "type": "GDExtensionObjectPtr",
+                "description": [
+                    "A pointer to the newly created Object."
+                ]
+            },
+            "arguments": [
+                {
+                    "name": "p_classname",
+                    "type": "GDExtensionConstStringNamePtr",
+                    "description": [
+                        "A pointer to a StringName with the class name."
+                    ]
+                }
+            ],
+            "description": [
+                "Constructs an Object of the requested class.",
+                "The passed class must be a built-in godot class, or an already-registered extension class. In both cases, object_set_instance() should be called to fully initialize the object.",
+                "If the type is a subtype of RefCounted, it already has a refcount of 1. The caller must take ownership the refcount and is responsible for decrementing it again when the object is no longer needed.",
+                "",
+                "\"NOTIFICATION_POSTINITIALIZE\" must be sent after construction."
+            ],
+            "since": "4.7"
         },
         {
             "name": "classdb_get_method_bind",
@@ -8367,7 +8601,7 @@
             "since": "4.1",
             "deprecated": {
                 "since": "4.2",
-                "replace_with": "classdb_register_extension_class5"
+                "replace_with": "classdb_register_extension_class6"
             }
         },
         {
@@ -8409,7 +8643,7 @@
             "since": "4.2",
             "deprecated": {
                 "since": "4.3",
-                "replace_with": "classdb_register_extension_class5"
+                "replace_with": "classdb_register_extension_class6"
             }
         },
         {
@@ -8451,7 +8685,7 @@
             "since": "4.3",
             "deprecated": {
                 "since": "4.4",
-                "replace_with": "classdb_register_extension_class5"
+                "replace_with": "classdb_register_extension_class6"
             }
         },
         {
@@ -8493,7 +8727,7 @@
             "since": "4.4",
             "deprecated": {
                 "since": "4.5",
-                "replace_with": "classdb_register_extension_class5"
+                "replace_with": "classdb_register_extension_class6"
             }
         },
         {
@@ -8532,7 +8766,49 @@
                 "Registers an extension class in the ClassDB.",
                 "Provided struct can be safely freed once the function returns."
             ],
-            "since": "4.5"
+            "since": "4.5",
+            "deprecated": {
+                "since": "4.7",
+                "replace_with": "classdb_register_extension_class6"
+            }
+        },
+        {
+            "name": "classdb_register_extension_class6",
+            "arguments": [
+                {
+                    "name": "p_library",
+                    "type": "GDExtensionClassLibraryPtr",
+                    "description": [
+                        "A pointer the library received by the GDExtension's entry point function."
+                    ]
+                },
+                {
+                    "name": "p_class_name",
+                    "type": "GDExtensionConstStringNamePtr",
+                    "description": [
+                        "A pointer to a StringName with the class name."
+                    ]
+                },
+                {
+                    "name": "p_parent_class_name",
+                    "type": "GDExtensionConstStringNamePtr",
+                    "description": [
+                        "A pointer to a StringName with the parent class name."
+                    ]
+                },
+                {
+                    "name": "p_extension_funcs",
+                    "type": "const GDExtensionClassCreationInfo6*",
+                    "description": [
+                        "A pointer to a GDExtensionClassCreationInfo6 struct."
+                    ]
+                }
+            ],
+            "description": [
+                "Registers an extension class in the ClassDB.",
+                "Provided struct can be safely freed once the function returns."
+            ],
+            "since": "4.7"
         },
         {
             "name": "classdb_register_extension_class_method",

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -176,7 +176,10 @@ def scons_generate_bindings(target, source, env):
     return None
 
 
-supported_api_versions = ["4.3", "4.4", "4.5", "4.6"]
+supported_api_versions = ["4.3", "4.4", "4.5", "4.6", "4.7"]
+
+# We default to the latest stable Godot version.
+default_api_version = "4.6"
 
 platforms = ["linux", "macos", "windows", "android", "ios", "web"]
 
@@ -549,7 +552,7 @@ def generate(env):
 
 
 def _get_api_file(extension_dir, api_version):
-    if api_version is None or api_version == supported_api_versions[-1]:
+    if api_version is None or api_version == default_api_version:
         return os.path.join(extension_dir, "extension_api.json")
 
     filename = "extension_api-%s.json" % api_version.replace(".", "-")


### PR DESCRIPTION
This PR aims to update the GDExtension interface and API files for Godot 4.7-beta1, and make some small build system changes, so that we still default to using the latest stable Godot version (4.6)

This is a DRAFT because Godot 4.7-beta1 still isn't out yet!

But this let's us get ready a bit, and let's me make some follow-up PRs that use the new stuff :-)