### PR TITLE
Optimize `Object::cast_to<T>()` using `Object::is_class()` now that it takes a `StringName`

### DIFF
--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -118,28 +118,20 @@ public:
 
 template <typename T>
 T *Object::cast_to(Object *p_object) {
-	if (p_object == nullptr) {
-		return nullptr;
-	}
-	StringName class_name = T::get_class_static();
-	GDExtensionObjectPtr casted = ::godot::gdextension_interface::object_cast_to(p_object->_owner, ::godot::gdextension_interface::classdb_get_class_tag(class_name._native_ptr()));
-	if (casted == nullptr) {
-		return nullptr;
-	}
-	return dynamic_cast<T *>(::godot::internal::get_object_instance_binding(casted));
+#if GODOT_VERSION_MINOR >= 7
+	return p_object && p_object->is_class(T::get_class_static()) ? static_cast<T *>(p_object) : nullptr;
+#else
+	return p_object ? dynamic_cast<T *>(p_object) : nullptr;
+#endif
 }
 
 template <typename T>
 const T *Object::cast_to(const Object *p_object) {
-	if (p_object == nullptr) {
-		return nullptr;
-	}
-	StringName class_name = T::get_class_static();
-	GDExtensionObjectPtr casted = ::godot::gdextension_interface::object_cast_to(p_object->_owner, ::godot::gdextension_interface::classdb_get_class_tag(class_name._native_ptr()));
-	if (casted == nullptr) {
-		return nullptr;
-	}
-	return dynamic_cast<const T *>(::godot::internal::get_object_instance_binding(casted));
+#if GODOT_VERSION_MINOR >= 7
+	return p_object && p_object->is_class(T::get_class_static()) ? static_cast<T *>(p_object) : nullptr;
+#else
+	return p_object ? dynamic_cast<T *>(p_object) : nullptr;
+#endif
 }
 
 } // namespace godot


### PR DESCRIPTION
After https://github.com/godotengine/godot/pull/118582, in Godot 4.7, `Object::is_class()` now takes a `StringName` which allows us to write a much simpler and faster version of `Object::cast_to<T>()` that doesn't use `dynamic_cast<T>()`

I've also chosen to simplify the code for Godot 4.6 and earlier to _only_ do the `dynamic_cast<T>()`. Since we have to do that in the end anyway, we may as well skip all the other junk. This is theoretically slower if the object can't be cast to the requested type, but faster if it can, so I expect it to be a wash

~~This is marked as a DRAFT because it depends on https://github.com/godotengine/godot-cpp/pull/1972~~