### PR TITLE
Add godot-cpp.natvis debug visualizers

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -365,8 +365,9 @@ function(godotcpp_generate)
     add_library(godot::cpp ALIAS godot-cpp)
 
     file(GLOB_RECURSE GODOTCPP_SOURCES LIST_DIRECTORIES NO CONFIGURE_DEPENDS src/*.cpp)
+    set(GODOTCPP_NATVIS_FILES natvis/godot-cpp.natvis)
 
-    target_sources(godot-cpp PRIVATE ${GODOTCPP_SOURCES} ${GENERATED_FILES_LIST})
+    target_sources(godot-cpp PRIVATE ${GODOTCPP_SOURCES} ${GENERATED_FILES_LIST} ${GODOTCPP_NATVIS_FILES})
 
     target_include_directories(
         godot-cpp

--- a/natvis/godot-cpp.natvis
+++ b/natvis/godot-cpp.natvis
@@ -1,0 +1,435 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="Ref&lt;*&gt;">
+		<SmartPointer Usage="Minimal">reference</SmartPointer>
+		<DisplayString Condition="!reference">[empty]</DisplayString>
+		<DisplayString Condition="!!reference">{*reference}</DisplayString>
+		<Expand>
+			<Item Condition="!!reference" Name="[ptr]">reference</Item>
+			<Item Condition="!!reference" Name="[refcount]">reference->refcount.count.value</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Vector&lt;*&gt;">
+		<Expand>
+			<Item Name="[size]">_cowdata._ptr ? (((const unsigned long long *)(_cowdata._ptr))[-1]) : 0</Item>
+			<ArrayItems>
+				<Size>_cowdata._ptr ? (((const unsigned long long *)(_cowdata._ptr))[-1]) : 0</Size>
+				<ValuePointer>($T1 *) _cowdata._ptr</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="Array">
+		<Expand>
+			<Item Name="[size]">_p->array._cowdata._ptr ? (((const unsigned long long *)(_p->array._cowdata._ptr))[-1]) : 0</Item>
+			<ArrayItems>
+				<Size>_p->array._cowdata._ptr ? (((const unsigned long long *)(_p->array._cowdata._ptr))[-1]) : 0</Size>
+				<ValuePointer>(Variant *) _p->array._cowdata._ptr</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="Dictionary">
+		<Expand>
+			<Item Name="[size]">_p &amp;&amp; _p->variant_map._head_element ? _p->variant_map._size : 0</Item>
+			<LinkedListItems>
+				<Size>_p &amp;&amp; _p->variant_map._head_element ? _p->variant_map._size : 0</Size>
+				<HeadPointer>_p ? _p->variant_map._head_element : nullptr</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode Name="[{data.key}]">(*this),view(MapHelper)</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<Type Name="LocalVector&lt;*&gt;">
+		<Expand>
+			<Item Name="[size]">count</Item>
+			<ArrayItems>
+				<Size>count</Size>
+				<ValuePointer>data</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="List&lt;*&gt;">
+		<Expand>
+			<Item Name="[size]">_data ? (_data->size_cache) : 0</Item>
+			<LinkedListItems>
+				<Size>_data ? (_data->size_cache) : 0</Size>
+				<HeadPointer>_data->first</HeadPointer>
+				<NextPointer>next_ptr</NextPointer>
+				<ValueNode>value</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<Type Name="NodePath">
+		<DisplayString Condition="!data">[empty]</DisplayString>
+		<DisplayString Condition="!!data">{{[absolute] = {data->absolute} [path] = {data->path,view(NodePathHelper)} [subpath] = {data->subpath,view(NodePathHelper)}}}</DisplayString>
+		<Expand>
+			<Item Name="[path]">data->path,view(NodePathHelper)</Item>
+			<Item Name="[subpath]">data->subpath,view(NodePathHelper)</Item>
+			<Item Name="[absolute]">data->absolute</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Vector&lt;StringName&gt;" IncludeView="NodePathHelper">
+		<Expand>
+			<ArrayItems>
+				<Size>_cowdata._ptr ? (((const unsigned long long *)(_cowdata._ptr))[-1]) : 0</Size>
+				<ValuePointer>((StringName *)_cowdata._ptr),view(NodePathHelper)</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="StringName" IncludeView="NodePathHelper">
+		<DisplayString Condition="_data &amp;&amp; _data->cname">{_data->cname,s8b}</DisplayString>
+		<DisplayString Condition="_data &amp;&amp; !_data->cname">{_data->name,s32b}</DisplayString>
+		<DisplayString Condition="!_data">[empty]</DisplayString>
+		<StringView Condition="_data &amp;&amp; _data->cname">_data->cname,s8b</StringView>
+		<StringView Condition="_data &amp;&amp; !_data->cname">_data->name,s32b</StringView>
+	</Type>
+
+	<Type Name="HashSet&lt;*,*,*&gt;">
+		<Expand>
+			<Item Name="[size]">_size</Item>
+			<ArrayItems>
+				<Size>_size</Size>
+				<ValuePointer>($T1 *) _keys._cowdata._ptr</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="HashMapElement&lt;*,*&gt;">
+		<DisplayString>{{Key = {($T1 *) &amp;data.key}  Value = {($T2 *) &amp;data.value}}}</DisplayString>
+		<Expand>
+			<Item Name="[key]">($T1 *) &amp;data.key</Item>
+			<Item Name="[value]">($T2 *) &amp;data.value</Item>
+		</Expand>
+	</Type>
+
+	<!-- elements displayed by index -->
+	<Type Name="HashMap&lt;*,*,*,*,*&gt;" Priority="Medium">
+		<Expand>
+			<Item Name="[size]">_head_element ? _size : 0</Item>
+			<LinkedListItems>
+				<Size>_head_element ? _size : 0</Size>
+				<HeadPointer>_head_element</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode>(*this)</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<!-- elements by key:value -->
+	<!-- show elements by index by specifying "ShowElementsByIndex"-->
+	<Type Name="HashMap&lt;*,*,*,*,*&gt;" ExcludeView="ShowElementsByIndex" Priority="MediumHigh">
+		<Expand>
+			<Item Name="[size]">_head_element ? _size : 0</Item>
+			<LinkedListItems>
+				<Size>_head_element ? _size : 0</Size>
+				<HeadPointer>_head_element</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode Name="[{data.key}]">(*this),view(MapHelper)</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<Type Name="KeyValue&lt;*,*&gt;" IncludeView="MapHelper">
+		<DisplayString>{value}</DisplayString>
+	</Type>
+
+	<Type Name="HashMapElement&lt;*,*&gt;" IncludeView="MapHelper">
+		<DisplayString>{data.value}</DisplayString>
+		<Expand>
+			<Item Name="[key]">($T1 *) &amp;data.key</Item>
+			<Item Name="[value]">($T2 *) &amp;data.value</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="VMap&lt;*,*&gt;">
+		<Expand>
+			<Item Condition="_cowdata._ptr" Name="[size]">*(reinterpret_cast&lt;long long*&gt;(_cowdata._ptr) - 1)</Item>
+			<ArrayItems Condition="_cowdata._ptr">
+				<Size>*(reinterpret_cast&lt;long long*&gt;(_cowdata._ptr) - 1)</Size>
+				<ValuePointer>reinterpret_cast&lt;VMap&lt;$T1,$T2&gt;::Pair*&gt;(_cowdata._ptr)</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="VMap&lt;Callable,*&gt;::Pair">
+		<DisplayString Condition="dynamic_cast&lt;CallableCustomMethodPointerBase*&gt;(key.custom)">{dynamic_cast&lt;CallableCustomMethodPointerBase*&gt;(key.custom)->text}</DisplayString>
+	</Type>
+
+
+	<Type Name="Variant">
+		<DisplayString Condition="type == Variant::NIL">nil</DisplayString>
+		<DisplayString Condition="type == Variant::BOOL">{_data._bool}</DisplayString>
+		<DisplayString Condition="type == Variant::INT">{_data._int}</DisplayString>
+		<DisplayString Condition="type == Variant::FLOAT">{_data._float}</DisplayString>
+		<DisplayString Condition="type == Variant::TRANSFORM2D">{_data._transform2d}</DisplayString>
+		<DisplayString Condition="type == Variant::AABB">{_data._aabb}</DisplayString>
+		<DisplayString Condition="type == Variant::BASIS">{_data._basis}</DisplayString>
+		<DisplayString Condition="type == Variant::TRANSFORM3D">{_data._transform3d}</DisplayString>
+		<DisplayString Condition="type == Variant::PROJECTION">{_data._projection}</DisplayString>
+		<DisplayString Condition="type == Variant::STRING">{*(String *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::VECTOR2">{*(Vector2 *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::RECT2">{*(Rect2 *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::VECTOR3">{*(Vector3 *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::VECTOR4">{*(Vector4 *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::PLANE">{*(Plane *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::QUATERNION">{*(Quaternion *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::COLOR">{*(Color *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::STRING_NAME">{*(StringName *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::NODE_PATH">{*(NodePath *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::RID">{*(::RID *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::OBJECT">{*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj}</DisplayString>
+		<DisplayString Condition="type == Variant::DICTIONARY">{*(Dictionary *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::ARRAY">{*(Array *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR4_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type &lt; 0 || type >= Variant::VARIANT_MAX">[INVALID]</DisplayString>
+
+		<StringView Condition="type == Variant::STRING &amp;&amp; ((String *)(_data._mem))->_cowdata._ptr">((String *)(_data._mem))->_cowdata._ptr,s32</StringView>
+
+		<Expand>
+			<Item Name="[value]" Condition="type == Variant::BOOL">_data._bool</Item>
+			<Item Name="[value]" Condition="type == Variant::INT">_data._int</Item>
+			<Item Name="[value]" Condition="type == Variant::FLOAT">_data._float</Item>
+			<Item Name="[value]" Condition="type == Variant::TRANSFORM2D">_data._transform2d</Item>
+			<Item Name="[value]" Condition="type == Variant::AABB">_data._aabb</Item>
+			<Item Name="[value]" Condition="type == Variant::BASIS">_data._basis</Item>
+			<Item Name="[value]" Condition="type == Variant::TRANSFORM3D">_data._transform3d</Item>
+			<Item Name="[value]" Condition="type == Variant::STRING">*(String *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::VECTOR2">*(Vector2 *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::RECT2">*(Rect2 *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::VECTOR3">*(Vector3 *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::PLANE">*(Plane *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::QUATERNION">*(Quaternion *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::COLOR">*(Color *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::STRING_NAME">*(StringName *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::NODE_PATH">*(NodePath *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::RID">*(::RID *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::OBJECT">*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj</Item>
+			<Item Name="[value]" Condition="type == Variant::DICTIONARY">*(Dictionary *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::ARRAY">*(Array *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR4_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array</Item>
+
+		</Expand>
+	</Type>
+
+	<Type Name="String">
+		<DisplayString Condition="_cowdata._ptr == 0">[empty]</DisplayString>
+		<DisplayString Condition="_cowdata._ptr != 0">{_cowdata._ptr,s32}</DisplayString>
+		<StringView Condition="_cowdata._ptr != 0">_cowdata._ptr,s32</StringView>
+	</Type>
+
+	<Type Name="godot::String">
+		<DisplayString>{*reinterpret_cast&lt;void**&gt;(opaque),s32}</DisplayString>
+		<Expand>
+			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
+			<Item Name="string">*reinterpret_cast&lt;void**&gt;(opaque),s32</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="StringName">
+		<DisplayString Condition="_data">{_data->name,s32}</DisplayString>
+		<DisplayString Condition="!_data">[empty]</DisplayString>
+		<StringView Condition="_data">_data->name,s32</StringView>
+	</Type>
+
+	<!-- can't cast the opaque to ::StringName because Natvis does not support global namespace specifier? -->
+	<Type Name="godot::StringName">
+		<Intrinsic Name="get_data_ptr" Expression="(*reinterpret_cast&lt;const char32_t***&gt;(opaque))[1]" />
+		<DisplayString Condition="get_data_ptr()">{get_data_ptr(),s32}</DisplayString>
+		<Expand>
+			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
+			<Item Name="cname">get_data_ptr(),s32</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Object::SignalData">
+		<DisplayString Condition="user.name._cowdata._ptr">"{user.name}" {slot_map}</DisplayString>
+		<DisplayString Condition="!user.name._cowdata._ptr">"{slot_map}</DisplayString>
+	</Type>
+
+	<Type Name="Vector2">
+		<DisplayString>({x,g}, {y,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+		</Expand>
+	</Type>
+	<Type Name="Vector2i">
+		<DisplayString>({x}, {y})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Vector3">
+		<DisplayString>({x,g}, {y,g}, {z,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+		</Expand>
+	</Type>
+	<Type Name="Vector3i">
+		<DisplayString>({x}, {y}, {z})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Vector4">
+		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+	<Type Name="Vector4i">
+		<DisplayString>({x}, {y}, {z}, {w})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Quaternion">
+		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Color">
+		<DisplayString>({r,g}, {g,g}, {b,g}, {a,g})</DisplayString>
+		<Expand>
+			<Item Name="[red]">r</Item>
+			<Item Name="[green]">g</Item>
+			<Item Name="[blue]">b</Item>
+			<Item Name="[alpha]">a</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Rect2">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+	<Type Name="Rect2i">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="AABB">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Plane">
+		<DisplayString>[N: {normal}, D: {d,g}]</DisplayString>
+		<Expand>
+			<Item Name="[normal]">normal,nr</Item>
+			<Item Name="[d]">d</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Basis">
+		<DisplayString>[X: {rows[0]}, Y: {rows[1]}, Z: {rows[2]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">rows[0],nr</Item>
+			<Item Name="[y]">rows[1],nr</Item>
+			<Item Name="[z]">rows[2],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Transform2D">
+		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, O: {columns[2]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">columns[0],nr</Item>
+			<Item Name="[y]">columns[1],nr</Item>
+			<Item Name="[origin]">columns[2],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Transform3D">
+		<!-- Can't call column functions, so just pretend we can via obscene code duplication. -->
+		<DisplayString>[X: ({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g}), Y: ({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g}), Z: ({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g}), O: {origin}]</DisplayString>
+		<Expand>
+			<Synthetic Name="[x]">
+				<DisplayString>({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].x</Item>
+					<Item Name="[y]">basis.rows[1].x</Item>
+					<Item Name="[z]">basis.rows[2].x</Item>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[y]">
+				<DisplayString>({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].y</Item>
+					<Item Name="[y]">basis.rows[1].y</Item>
+					<Item Name="[z]">basis.rows[2].y</Item>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[z]">
+				<DisplayString>({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].z</Item>
+					<Item Name="[y]">basis.rows[1].z</Item>
+					<Item Name="[z]">basis.rows[2].z</Item>
+				</Expand>
+			</Synthetic>
+			<Item Name="[origin]">origin,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Projection">
+		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, Z: {columns[2]}, W: {columns[3]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">columns[0],nr</Item>
+			<Item Name="[y]">columns[1],nr</Item>
+			<Item Name="[z]">columns[2],nr</Item>
+			<Item Name="[w]">columns[3],nr</Item>
+		</Expand>
+	</Type>
+</AutoVisualizer>

--- a/natvis/godot-cpp.natvis
+++ b/natvis/godot-cpp.natvis
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="godot::String">
+		<DisplayString>{*reinterpret_cast&lt;void**&gt;(opaque),s32}</DisplayString>
+		<Expand>
+			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
+			<Item Name="string">*reinterpret_cast&lt;void**&gt;(opaque),s32</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::StringName">
+		<Intrinsic Name="get_data_ptr" Expression="(*reinterpret_cast&lt;const char32_t***&gt;(opaque))[1]"/>
+		<DisplayString Condition="get_data_ptr()">{get_data_ptr(),s32}</DisplayString>
+		<Expand>
+			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
+			<Item Name="cname">get_data_ptr(),s32</Item>
+		</Expand>
+	</Type>
+
+	<!-- Developer notes: https://jb.gg/godot-cpp-natvis -->
+
+	<!-- opaque[0..7] holds ArrayPrivate*. Dereference as unsigned long long* to read ArrayPrivate
+	     fields as 8-byte slots: [0]=refcount, [1]=unknown, [2]=_cowdata._ptr, [3]=read_only, ...
+	     Index [2] reaches _cowdata._ptr at offset +16 (verified by LLDB memory dump).
+	     Cast _ptr to unsigned long long* so [-1] reads the CowData element count 8 bytes before data. -->
+
+	<!-- _size() reads the CowData size field via an alignment-aware pointer.
+	     The allocator guarantees the size field starts on a 16-byte boundary,
+	     but _cow() points to the first data element (16 bytes past the size field)
+	     Subtracting 1 byte and masking with ~15 always lands on
+	     the closest 16-byte-aligned address at or just before _cow() - 1, which is
+	     exactly where, the size lives. -->
+	<Type Name="godot::Array">
+		<Intrinsic Name="_cow"
+		           Expression="(unsigned long long*)(*reinterpret_cast&lt;unsigned long long**&gt;(opaque))[2]"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(godot::Variant*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<!-- DictionaryPrivate layout (verified by LLDB console):
+	     [refcount(4)][unknown(4)][read_only(8)][HashMap at +16]
+	     HashMap: [_elements(8)][unknown(8)][_head(8)][_last(8)][_capacity_index(4)][_num_elements(4)]
+	     HashMapElement: [next(8)][prev(8)][key:Variant(24)][value:Variant(24)] -->
+	<Type Name="godot::Dictionary">
+		<Intrinsic Name="_p" Expression="*reinterpret_cast&lt;unsigned char**&gt;(opaque)"/>
+		<Intrinsic Name="_size" Expression="*(unsigned int*)(_p() + 52)"/>
+		<Intrinsic Name="_head" Expression="*reinterpret_cast&lt;unsigned char**&gt;(_p() + 32)"/>
+		<DisplayString Condition="!_p()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]">_size()</Item>
+			<CustomListItems MaxItemsPerView="5000">
+				<Variable Name="elem" InitialValue="(unsigned char*)_head()"/>
+				<Variable Name="idx" InitialValue="0"/>
+				<Loop Condition="elem != 0">
+					<Item Name="[{idx}]">(godot::Variant*)(elem + 16),[2]</Item>
+					<Exec>elem = *(unsigned char**)elem</Exec>
+					<Exec>idx++</Exec>
+				</Loop>
+			</CustomListItems>
+		</Expand>
+	</Type>
+
+	<!-- Variant::Type enum:
+	     NIL=0 BOOL=1 INT=2 FLOAT=3 STRING=4 VECTOR2=5 VECTOR2I=6 RECT2=7 RECT2I=8
+	     VECTOR3=9 VECTOR3I=10 TRANSFORM2D=11 VECTOR4=12 VECTOR4I=13 PLANE=14
+	     QUATERNION=15 AABB=16 BASIS=17 TRANSFORM3D=18 PROJECTION=19 COLOR=20
+	     STRING_NAME=21 NODE_PATH=22 RID=23 OBJECT=24 CALLABLE=25 SIGNAL=26
+	     DICTIONARY=27 ARRAY=28
+	     Layout: opaque[0..3]=type(int32), opaque[4..7]=pad, opaque[8..23]=_data union -->
+	<Type Name="godot::Variant">
+		<Intrinsic Name="_type" Expression="*reinterpret_cast&lt;int*&gt;(opaque)"/>
+		<DisplayString Condition="_type() == 0">nil</DisplayString>
+		<DisplayString Condition="_type() == 1">{*reinterpret_cast&lt;bool*&gt;(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 2">{*reinterpret_cast&lt;long long*&gt;(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 3">{*reinterpret_cast&lt;double*&gt;(opaque+8)}</DisplayString>
+		<!-- inline types: stored directly in _data._mem at opaque+8 -->
+		<DisplayString Condition="_type() == 4">{*(godot::String*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 5">{*(godot::Vector2*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 6">{*(godot::Vector2i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 7">{*(godot::Rect2*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 8">{*(godot::Rect2i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 9">{*(godot::Vector3*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 10">{*(godot::Vector3i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 12">{*(godot::Vector4*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 13">{*(godot::Vector4i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 14">{*(godot::Plane*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 15">{*(godot::Quaternion*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 20">{*(godot::Color*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 21">{*(godot::StringName*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 22">{*(godot::NodePath*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 23">{*(godot::RID*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 25">{*(godot::Callable*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 26">{*(godot::Signal*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 27">{*(godot::Dictionary*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 28">{*(godot::Array*)(opaque+8)}</DisplayString>
+		<!-- heap-allocated types: opaque+8 holds a pointer, double-deref required -->
+		<DisplayString Condition="_type() == 11">{**(godot::Transform2D**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 16">{**(godot::AABB**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 17">{**(godot::Basis**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 18">{**(godot::Transform3D**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 19">{**(godot::Projection**)(opaque+8)}</DisplayString>
+		<!-- OBJECT: opaque+8=ObjectID, opaque+16=Object* -->
+		<DisplayString Condition="_type() == 24">Object(id={*reinterpret_cast&lt;unsigned long long*&gt;(opaque+8)})
+		</DisplayString>
+		<DisplayString>{{type={_type()}}}</DisplayString>
+		<Expand>
+			<Item Name="[type]">_type()</Item>
+			<Item Name="[value]" Condition="_type() == 1">*reinterpret_cast&lt;bool*&gt;(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 2">*reinterpret_cast&lt;long long*&gt;(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 3">*reinterpret_cast&lt;double*&gt;(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 4">*(godot::String*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 5">*(godot::Vector2*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 6">*(godot::Vector2i*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 7">*(godot::Rect2*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 8">*(godot::Rect2i*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 9">*(godot::Vector3*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 10">*(godot::Vector3i*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 11">**(godot::Transform2D**)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 12">*(godot::Vector4*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 13">*(godot::Vector4i*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 14">*(godot::Plane*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 15">*(godot::Quaternion*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 16">**(godot::AABB**)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 17">**(godot::Basis**)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 18">**(godot::Transform3D**)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 19">**(godot::Projection**)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 20">*(godot::Color*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 21">*(godot::StringName*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 22">*(godot::NodePath*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 23">*(godot::RID*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 25">*(godot::Callable*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 26">*(godot::Signal*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 27">*(godot::Dictionary*)(opaque+8)</Item>
+			<Item Name="[value]" Condition="_type() == 28">*(godot::Array*)(opaque+8)</Item>
+		</Expand>
+	</Type>
+
+	<!-- godot::Packed*Array layout.
+	     opaque (16 bytes):
+	         [0..7]   reserved / 0 (godot-cpp over-allocates; engine type is 8 bytes)
+	         [8..15]  CowData<T>::_ptr  (T*)  - points to first data element
+	     CowData allocation block layout (same as godot::Array):
+	         _ptr - 16:  uint64_t               size      <- what _size() reads
+	         _ptr -  8:  SafeNumeric<uint64_t>  refcount
+	         _ptr +  0:  T  data[size]          <- _cow() points here
+	     _size() uses the alignment-aware formula: *(uint64_t*)(((_cow() - 1) as uintptr_t) & ~15)
+	     Subtracting 1 byte and masking with ~15 always lands on
+	     the closest 16-byte-aligned address at or just before _cow() - 1,
+	     which is exactly where, the size lives.
+	     Only <ValuePointer> differs between the Packed*Array types. -->
+
+	<Type Name="godot::PackedByteArray">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(unsigned char*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedInt32Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(int*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedInt64Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(long long*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedFloat32Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(float*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedFloat64Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(double*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedStringArray">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(godot::String*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedVector2Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(godot::Vector2*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedVector3Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(godot::Vector3*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedVector4Array">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(godot::Vector4*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::PackedColorArray">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(opaque + 8)"/>
+		<Intrinsic Name="_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_cow() - 1))&amp;~(uintptr_t) 15))"/>
+		<DisplayString Condition="!_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
+		<Expand>
+			<Item Name="[size]" Condition="!_cow()">0,d</Item>
+			<Item Name="[size]" Condition="_cow()">_size()</Item>
+			<ArrayItems Condition="_cow()">
+				<Size>_size()</Size>
+				<ValuePointer>(godot::Color*)_cow()</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Vector2">
+		<DisplayString>({x,g}, {y,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Vector2i">
+		<DisplayString>({x}, {y})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Vector3">
+		<DisplayString>({x,g}, {y,g}, {z,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Vector3i">
+		<DisplayString>({x}, {y}, {z})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Vector4">
+		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Vector4i">
+		<DisplayString>({x}, {y}, {z}, {w})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Quaternion">
+		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Color">
+		<DisplayString>({r,g}, {g,g}, {b,g}, {a,g})</DisplayString>
+		<Expand>
+			<Item Name="[red]">r</Item>
+			<Item Name="[green]">g</Item>
+			<Item Name="[blue]">b</Item>
+			<Item Name="[alpha]">a</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Plane">
+		<DisplayString>[N: {normal}, D: {d,g}]</DisplayString>
+		<Expand>
+			<Item Name="[normal]">normal,nr</Item>
+			<Item Name="[d]">d</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Rect2">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Rect2i">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::AABB">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Basis">
+		<DisplayString>[X: {rows[0]}, Y: {rows[1]}, Z: {rows[2]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">rows[0],nr</Item>
+			<Item Name="[y]">rows[1],nr</Item>
+			<Item Name="[z]">rows[2],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Projection">
+		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, Z: {columns[2]}, W: {columns[3]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">columns[0],nr</Item>
+			<Item Name="[y]">columns[1],nr</Item>
+			<Item Name="[z]">columns[2],nr</Item>
+			<Item Name="[w]">columns[3],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Transform2D">
+		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, O: {columns[2]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">columns[0],nr</Item>
+			<Item Name="[y]">columns[1],nr</Item>
+			<Item Name="[origin]">columns[2],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::Transform3D">
+		<DisplayString>[X: ({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g}), Y: ({basis.rows[0].y,g},
+			{basis.rows[1].y,g}, {basis.rows[2].y,g}), Z: ({basis.rows[0].z,g}, {basis.rows[1].z,g},
+			{basis.rows[2].z,g}), O: {origin}]
+		</DisplayString>
+		<Expand>
+			<Synthetic Name="[x]">
+				<DisplayString>({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].x</Item>
+					<Item Name="[y]">basis.rows[1].x</Item>
+					<Item Name="[z]">basis.rows[2].x</Item>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[y]">
+				<DisplayString>({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].y</Item>
+					<Item Name="[y]">basis.rows[1].y</Item>
+					<Item Name="[z]">basis.rows[2].y</Item>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[z]">
+				<DisplayString>({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].z</Item>
+					<Item Name="[y]">basis.rows[1].z</Item>
+					<Item Name="[z]">basis.rows[2].z</Item>
+				</Expand>
+			</Synthetic>
+			<Item Name="[origin]">origin,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="godot::NodePath">
+		<Intrinsic Name="_cow"
+		           Expression="*reinterpret_cast&lt;unsigned char**&gt;(opaque)"/>
+		<Intrinsic Name="_path_ptr"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(_cow() + 16)"/>
+		<Intrinsic Name="_subpath_ptr"
+		           Expression="*reinterpret_cast&lt;unsigned long long**&gt;(_cow() + 24)"/>
+		<Intrinsic Name="_path_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_path_ptr() - 1))&amp;~(uintptr_t) 15))"/>
+		<Intrinsic Name="_subpath_size"
+		           Expression="*((unsigned long long*)(((uintptr_t)(_subpath_ptr() - 1))&amp;~(uintptr_t) 15))"/>
+		<Intrinsic Name="_absolute" Expression="*(bool*)(_cow() + 32)"/>
+		<DisplayString Condition="!_cow()">[empty]</DisplayString>
+		<DisplayString>{{absolute={_absolute()}, path[{_path_size()}], subpath[{_subpath_size()}]}}
+		</DisplayString>
+		<Expand>
+			<Item Name="[absolute]">_absolute()</Item>
+			<Synthetic Name="[path]">
+				<DisplayString Condition="!_path_ptr()">[empty]</DisplayString>
+				<DisplayString>{{size={_path_size()}}}</DisplayString>
+				<Expand>
+					<ArrayItems Condition="_path_ptr()">
+						<Size>_path_size()</Size>
+						<ValuePointer>(godot::StringName*)_path_ptr()</ValuePointer>
+					</ArrayItems>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[subpath]">
+				<DisplayString Condition="!_subpath_ptr()">[empty]</DisplayString>
+				<DisplayString>{{size={_subpath_size()}}}</DisplayString>
+				<Expand>
+					<ArrayItems Condition="_subpath_ptr()">
+						<Size>_subpath_size()</Size>
+						<ValuePointer>(godot::StringName*)_subpath_ptr()</ValuePointer>
+					</ArrayItems>
+				</Expand>
+			</Synthetic>
+		</Expand>
+	</Type>
+</AutoVisualizer>

--- a/natvis/godot-cpp.natvis
+++ b/natvis/godot-cpp.natvis
@@ -17,10 +17,31 @@
 		</Expand>
 	</Type>
 
-	<!-- Development notes: there is no way to just ask AI to generate natvis entry for each `godot::` type
-	Each type required evaluation with LLDB console
+	<!-- Development notes: At the current state no AI can directly generate a natvis entry for each `godot::` type.
 	The testdata used for evaluation https://github.com/JetBrains/godot-support/wiki/Developing-godot%E2%80%90cpp.natvis
 	The change of the memory layout would require adjustments of the natvis
+
+	Approach:
+	1. For each type, inspect `opaque` bytes in LLDB using `memory read -size 8 -count N -format address` on
+	   the address stored in opaque (e.g. `*(void**)demo_type.opaque`) to map the actual field layout.
+	2. Verify specific field values match known test data (e.g. array size=1, int value=42, string content).
+	3. Write natvis expressions only after the field offsets are confirmed.
+
+	Evaluator constraints (JetBrains natvis engine, I haven't checked anything else):
+	- Supports: reinterpret_cast, pointer arithmetic on built-in types, array indexing ([n]), Intrinsics
+	- Does NOT support: calling member functions (e.g. size())
+	- Nested type visualizers work: `{*(godot::String*)(opaque+8)}` delegates to the String natvis entry
+
+	Patterns used:
+	- Opaque wrapper types (String, StringName, Array, Dictionary, ...): cast opaque slice to the
+	  godot-cpp type pointer — `*(godot::TypeName*)(opaque+N)` — and let that type's natvis handle display
+	- Engine heap-allocated types stored as pointer (Transform2D, AABB, Basis, ...): double-deref —
+	  `**(godot::TypeName**)(opaque+N)`
+	- Engine internals without a godot-cpp wrapper (ArrayPrivate, CowData, HashMap): use raw
+	  reinterpret_cast + index arithmetic, document offsets with a comment verified by LLDB
+
+	Future upcomming improvements:
+	- JetBrains natvis support is going to become x-plat https://youtrack.jetbrains.com/issue/CPP-35297
 	-->
 
 	<!-- opaque[0..7] holds ArrayPrivate*. Dereference as unsigned long long* to read ArrayPrivate

--- a/natvis/godot-cpp.natvis
+++ b/natvis/godot-cpp.natvis
@@ -77,8 +77,7 @@
 				<Variable Name="elem" InitialValue="(unsigned char*)_head()"/>
 				<Variable Name="idx"  InitialValue="0"/>
 				<Loop Condition="elem != 0">
-					<Item Name="[{idx}].key">*(godot::Variant*)(elem + 16)</Item>
-					<Item Name="[{idx}].value">*(godot::Variant*)(elem + 40)</Item>
+					<Item Name="[{idx}]">(godot::Variant*)(elem + 16),[2]</Item>
 					<Exec>elem = *(unsigned char**)elem</Exec>
 					<Exec>idx++</Exec>
 				</Loop>

--- a/natvis/godot-cpp.natvis
+++ b/natvis/godot-cpp.natvis
@@ -9,7 +9,7 @@
 	</Type>
 
 	<Type Name="godot::StringName">
-		<Intrinsic Name="get_data_ptr" Expression="(*reinterpret_cast&lt;const char32_t***&gt;(opaque))[1]" />
+		<Intrinsic Name="get_data_ptr" Expression="(*reinterpret_cast&lt;const char32_t***&gt;(opaque))[1]"/>
 		<DisplayString Condition="get_data_ptr()">{get_data_ptr(),s32}</DisplayString>
 		<Expand>
 			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
@@ -17,39 +17,15 @@
 		</Expand>
 	</Type>
 
-	<!-- Development notes: At the current state no AI can directly generate a natvis entry for each `godot::` type.
-	The testdata used for evaluation https://github.com/JetBrains/godot-support/wiki/Developing-godot%E2%80%90cpp.natvis
-	The change of the memory layout would require adjustments of the natvis
-
-	Approach:
-	1. For each type, inspect `opaque` bytes in LLDB using `memory read -size 8 -count N -format address` on
-	   the address stored in opaque (e.g. `*(void**)demo_type.opaque`) to map the actual field layout.
-	2. Verify specific field values match known test data (e.g. array size=1, int value=42, string content).
-	3. Write natvis expressions only after the field offsets are confirmed.
-
-	Evaluator constraints (JetBrains natvis engine, I haven't checked anything else):
-	- Supports: reinterpret_cast, pointer arithmetic on built-in types, array indexing ([n]), Intrinsics
-	- Does NOT support: calling member functions (e.g. size())
-	- Nested type visualizers work: `{*(godot::String*)(opaque+8)}` delegates to the String natvis entry
-
-	Patterns used:
-	- Opaque wrapper types (String, StringName, Array, Dictionary, ...): cast opaque slice to the
-	  godot-cpp type pointer — `*(godot::TypeName*)(opaque+N)` — and let that type's natvis handle display
-	- Engine heap-allocated types stored as pointer (Transform2D, AABB, Basis, ...): double-deref —
-	  `**(godot::TypeName**)(opaque+N)`
-	- Engine internals without a godot-cpp wrapper (ArrayPrivate, CowData, HashMap): use raw
-	  reinterpret_cast + index arithmetic, document offsets with a comment verified by LLDB
-
-	Future upcomming improvements:
-	- JetBrains natvis support is going to become x-plat https://youtrack.jetbrains.com/issue/CPP-35297
-	-->
+	<!-- Developer notes: https://jb.gg/godot-cpp-natvis -->
 
 	<!-- opaque[0..7] holds ArrayPrivate*. Dereference as unsigned long long* to read ArrayPrivate
 	     fields as 8-byte slots: [0]=refcount, [1]=unknown, [2]=_cowdata._ptr, [3]=read_only, ...
 	     Index [2] reaches _cowdata._ptr at offset +16 (verified by LLDB memory dump).
 	     Cast _ptr to unsigned long long* so [-1] reads the CowData element count 8 bytes before data. -->
 	<Type Name="godot::Array">
-		<Intrinsic Name="_cow" Expression="(unsigned long long*)(*reinterpret_cast&lt;unsigned long long**&gt;(opaque))[2]" />
+		<Intrinsic Name="_cow"
+		           Expression="(unsigned long long*)(*reinterpret_cast&lt;unsigned long long**&gt;(opaque))[2]"/>
 		<DisplayString Condition="!*reinterpret_cast&lt;void**&gt;(opaque) || !_cow()">{{empty}}</DisplayString>
 		<DisplayString>{{size={_cow()[-1]}}}</DisplayString>
 		<Expand>
@@ -66,16 +42,16 @@
 	     HashMap: [_elements(8)][unknown(8)][_head(8)][_last(8)][_capacity_index(4)][_num_elements(4)]
 	     HashMapElement: [next(8)][prev(8)][key:Variant(24)][value:Variant(24)] -->
 	<Type Name="godot::Dictionary">
-		<Intrinsic Name="_p"    Expression="*reinterpret_cast&lt;unsigned char**&gt;(opaque)" />
-		<Intrinsic Name="_size" Expression="*(unsigned int*)(_p() + 52)" />
-		<Intrinsic Name="_head" Expression="*reinterpret_cast&lt;unsigned char**&gt;(_p() + 32)" />
+		<Intrinsic Name="_p" Expression="*reinterpret_cast&lt;unsigned char**&gt;(opaque)"/>
+		<Intrinsic Name="_size" Expression="*(unsigned int*)(_p() + 52)"/>
+		<Intrinsic Name="_head" Expression="*reinterpret_cast&lt;unsigned char**&gt;(_p() + 32)"/>
 		<DisplayString Condition="!_p()">{{empty}}</DisplayString>
 		<DisplayString>{{size={_size()}}}</DisplayString>
 		<Expand>
 			<Item Name="[size]">_size()</Item>
 			<CustomListItems MaxItemsPerView="5000">
 				<Variable Name="elem" InitialValue="(unsigned char*)_head()"/>
-				<Variable Name="idx"  InitialValue="0"/>
+				<Variable Name="idx" InitialValue="0"/>
 				<Loop Condition="elem != 0">
 					<Item Name="[{idx}]">(godot::Variant*)(elem + 16),[2]</Item>
 					<Exec>elem = *(unsigned char**)elem</Exec>
@@ -93,7 +69,7 @@
 	     DICTIONARY=27 ARRAY=28
 	     Layout: opaque[0..3]=type(int32), opaque[4..7]=pad, opaque[8..23]=_data union -->
 	<Type Name="godot::Variant">
-		<Intrinsic Name="_type" Expression="*reinterpret_cast&lt;int*&gt;(opaque)" />
+		<Intrinsic Name="_type" Expression="*reinterpret_cast&lt;int*&gt;(opaque)"/>
 		<DisplayString Condition="_type() == 0">nil</DisplayString>
 		<DisplayString Condition="_type() == 1">{*reinterpret_cast&lt;bool*&gt;(opaque+8)}</DisplayString>
 		<DisplayString Condition="_type() == 2">{*reinterpret_cast&lt;long long*&gt;(opaque+8)}</DisplayString>
@@ -125,7 +101,8 @@
 		<DisplayString Condition="_type() == 18">{**(godot::Transform3D**)(opaque+8)}</DisplayString>
 		<DisplayString Condition="_type() == 19">{**(godot::Projection**)(opaque+8)}</DisplayString>
 		<!-- OBJECT: opaque+8=ObjectID, opaque+16=Object* -->
-		<DisplayString Condition="_type() == 24">Object(id={*reinterpret_cast&lt;unsigned long long*&gt;(opaque+8)})</DisplayString>
+		<DisplayString Condition="_type() == 24">Object(id={*reinterpret_cast&lt;unsigned long long*&gt;(opaque+8)})
+		</DisplayString>
 		<DisplayString>{{type={_type()}}}</DisplayString>
 		<Expand>
 			<Item Name="[type]">_type()</Item>

--- a/natvis/godot-cpp.natvis
+++ b/natvis/godot-cpp.natvis
@@ -1,247 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-	<Type Name="Ref&lt;*&gt;">
-		<SmartPointer Usage="Minimal">reference</SmartPointer>
-		<DisplayString Condition="!reference">[empty]</DisplayString>
-		<DisplayString Condition="!!reference">{*reference}</DisplayString>
-		<Expand>
-			<Item Condition="!!reference" Name="[ptr]">reference</Item>
-			<Item Condition="!!reference" Name="[refcount]">reference->refcount.count.value</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Vector&lt;*&gt;">
-		<Expand>
-			<Item Name="[size]">_cowdata._ptr ? (((const unsigned long long *)(_cowdata._ptr))[-1]) : 0</Item>
-			<ArrayItems>
-				<Size>_cowdata._ptr ? (((const unsigned long long *)(_cowdata._ptr))[-1]) : 0</Size>
-				<ValuePointer>($T1 *) _cowdata._ptr</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
-	<Type Name="Array">
-		<Expand>
-			<Item Name="[size]">_p->array._cowdata._ptr ? (((const unsigned long long *)(_p->array._cowdata._ptr))[-1]) : 0</Item>
-			<ArrayItems>
-				<Size>_p->array._cowdata._ptr ? (((const unsigned long long *)(_p->array._cowdata._ptr))[-1]) : 0</Size>
-				<ValuePointer>(Variant *) _p->array._cowdata._ptr</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
-	<Type Name="Dictionary">
-		<Expand>
-			<Item Name="[size]">_p &amp;&amp; _p->variant_map._head_element ? _p->variant_map._size : 0</Item>
-			<LinkedListItems>
-				<Size>_p &amp;&amp; _p->variant_map._head_element ? _p->variant_map._size : 0</Size>
-				<HeadPointer>_p ? _p->variant_map._head_element : nullptr</HeadPointer>
-				<NextPointer>next</NextPointer>
-				<ValueNode Name="[{data.key}]">(*this),view(MapHelper)</ValueNode>
-			</LinkedListItems>
-		</Expand>
-	</Type>
-
-	<Type Name="LocalVector&lt;*&gt;">
-		<Expand>
-			<Item Name="[size]">count</Item>
-			<ArrayItems>
-				<Size>count</Size>
-				<ValuePointer>data</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
-	<Type Name="List&lt;*&gt;">
-		<Expand>
-			<Item Name="[size]">_data ? (_data->size_cache) : 0</Item>
-			<LinkedListItems>
-				<Size>_data ? (_data->size_cache) : 0</Size>
-				<HeadPointer>_data->first</HeadPointer>
-				<NextPointer>next_ptr</NextPointer>
-				<ValueNode>value</ValueNode>
-			</LinkedListItems>
-		</Expand>
-	</Type>
-
-	<Type Name="NodePath">
-		<DisplayString Condition="!data">[empty]</DisplayString>
-		<DisplayString Condition="!!data">{{[absolute] = {data->absolute} [path] = {data->path,view(NodePathHelper)} [subpath] = {data->subpath,view(NodePathHelper)}}}</DisplayString>
-		<Expand>
-			<Item Name="[path]">data->path,view(NodePathHelper)</Item>
-			<Item Name="[subpath]">data->subpath,view(NodePathHelper)</Item>
-			<Item Name="[absolute]">data->absolute</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Vector&lt;StringName&gt;" IncludeView="NodePathHelper">
-		<Expand>
-			<ArrayItems>
-				<Size>_cowdata._ptr ? (((const unsigned long long *)(_cowdata._ptr))[-1]) : 0</Size>
-				<ValuePointer>((StringName *)_cowdata._ptr),view(NodePathHelper)</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
-	<Type Name="StringName" IncludeView="NodePathHelper">
-		<DisplayString Condition="_data &amp;&amp; _data->cname">{_data->cname,s8b}</DisplayString>
-		<DisplayString Condition="_data &amp;&amp; !_data->cname">{_data->name,s32b}</DisplayString>
-		<DisplayString Condition="!_data">[empty]</DisplayString>
-		<StringView Condition="_data &amp;&amp; _data->cname">_data->cname,s8b</StringView>
-		<StringView Condition="_data &amp;&amp; !_data->cname">_data->name,s32b</StringView>
-	</Type>
-
-	<Type Name="HashSet&lt;*,*,*&gt;">
-		<Expand>
-			<Item Name="[size]">_size</Item>
-			<ArrayItems>
-				<Size>_size</Size>
-				<ValuePointer>($T1 *) _keys._cowdata._ptr</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
-	<Type Name="HashMapElement&lt;*,*&gt;">
-		<DisplayString>{{Key = {($T1 *) &amp;data.key}  Value = {($T2 *) &amp;data.value}}}</DisplayString>
-		<Expand>
-			<Item Name="[key]">($T1 *) &amp;data.key</Item>
-			<Item Name="[value]">($T2 *) &amp;data.value</Item>
-		</Expand>
-	</Type>
-
-	<!-- elements displayed by index -->
-	<Type Name="HashMap&lt;*,*,*,*,*&gt;" Priority="Medium">
-		<Expand>
-			<Item Name="[size]">_head_element ? _size : 0</Item>
-			<LinkedListItems>
-				<Size>_head_element ? _size : 0</Size>
-				<HeadPointer>_head_element</HeadPointer>
-				<NextPointer>next</NextPointer>
-				<ValueNode>(*this)</ValueNode>
-			</LinkedListItems>
-		</Expand>
-	</Type>
-
-	<!-- elements by key:value -->
-	<!-- show elements by index by specifying "ShowElementsByIndex"-->
-	<Type Name="HashMap&lt;*,*,*,*,*&gt;" ExcludeView="ShowElementsByIndex" Priority="MediumHigh">
-		<Expand>
-			<Item Name="[size]">_head_element ? _size : 0</Item>
-			<LinkedListItems>
-				<Size>_head_element ? _size : 0</Size>
-				<HeadPointer>_head_element</HeadPointer>
-				<NextPointer>next</NextPointer>
-				<ValueNode Name="[{data.key}]">(*this),view(MapHelper)</ValueNode>
-			</LinkedListItems>
-		</Expand>
-	</Type>
-
-	<Type Name="KeyValue&lt;*,*&gt;" IncludeView="MapHelper">
-		<DisplayString>{value}</DisplayString>
-	</Type>
-
-	<Type Name="HashMapElement&lt;*,*&gt;" IncludeView="MapHelper">
-		<DisplayString>{data.value}</DisplayString>
-		<Expand>
-			<Item Name="[key]">($T1 *) &amp;data.key</Item>
-			<Item Name="[value]">($T2 *) &amp;data.value</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="VMap&lt;*,*&gt;">
-		<Expand>
-			<Item Condition="_cowdata._ptr" Name="[size]">*(reinterpret_cast&lt;long long*&gt;(_cowdata._ptr) - 1)</Item>
-			<ArrayItems Condition="_cowdata._ptr">
-				<Size>*(reinterpret_cast&lt;long long*&gt;(_cowdata._ptr) - 1)</Size>
-				<ValuePointer>reinterpret_cast&lt;VMap&lt;$T1,$T2&gt;::Pair*&gt;(_cowdata._ptr)</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
-	<Type Name="VMap&lt;Callable,*&gt;::Pair">
-		<DisplayString Condition="dynamic_cast&lt;CallableCustomMethodPointerBase*&gt;(key.custom)">{dynamic_cast&lt;CallableCustomMethodPointerBase*&gt;(key.custom)->text}</DisplayString>
-	</Type>
-
-
-	<Type Name="Variant">
-		<DisplayString Condition="type == Variant::NIL">nil</DisplayString>
-		<DisplayString Condition="type == Variant::BOOL">{_data._bool}</DisplayString>
-		<DisplayString Condition="type == Variant::INT">{_data._int}</DisplayString>
-		<DisplayString Condition="type == Variant::FLOAT">{_data._float}</DisplayString>
-		<DisplayString Condition="type == Variant::TRANSFORM2D">{_data._transform2d}</DisplayString>
-		<DisplayString Condition="type == Variant::AABB">{_data._aabb}</DisplayString>
-		<DisplayString Condition="type == Variant::BASIS">{_data._basis}</DisplayString>
-		<DisplayString Condition="type == Variant::TRANSFORM3D">{_data._transform3d}</DisplayString>
-		<DisplayString Condition="type == Variant::PROJECTION">{_data._projection}</DisplayString>
-		<DisplayString Condition="type == Variant::STRING">{*(String *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::VECTOR2">{*(Vector2 *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::RECT2">{*(Rect2 *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::VECTOR3">{*(Vector3 *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::VECTOR4">{*(Vector4 *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::PLANE">{*(Plane *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::QUATERNION">{*(Quaternion *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::COLOR">{*(Color *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::STRING_NAME">{*(StringName *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::NODE_PATH">{*(NodePath *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::RID">{*(::RID *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::OBJECT">{*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj}</DisplayString>
-		<DisplayString Condition="type == Variant::DICTIONARY">{*(Dictionary *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::ARRAY">{*(Array *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR4_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type &lt; 0 || type >= Variant::VARIANT_MAX">[INVALID]</DisplayString>
-
-		<StringView Condition="type == Variant::STRING &amp;&amp; ((String *)(_data._mem))->_cowdata._ptr">((String *)(_data._mem))->_cowdata._ptr,s32</StringView>
-
-		<Expand>
-			<Item Name="[value]" Condition="type == Variant::BOOL">_data._bool</Item>
-			<Item Name="[value]" Condition="type == Variant::INT">_data._int</Item>
-			<Item Name="[value]" Condition="type == Variant::FLOAT">_data._float</Item>
-			<Item Name="[value]" Condition="type == Variant::TRANSFORM2D">_data._transform2d</Item>
-			<Item Name="[value]" Condition="type == Variant::AABB">_data._aabb</Item>
-			<Item Name="[value]" Condition="type == Variant::BASIS">_data._basis</Item>
-			<Item Name="[value]" Condition="type == Variant::TRANSFORM3D">_data._transform3d</Item>
-			<Item Name="[value]" Condition="type == Variant::STRING">*(String *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::VECTOR2">*(Vector2 *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::RECT2">*(Rect2 *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::VECTOR3">*(Vector3 *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PLANE">*(Plane *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::QUATERNION">*(Quaternion *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::COLOR">*(Color *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::STRING_NAME">*(StringName *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::NODE_PATH">*(NodePath *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::RID">*(::RID *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::OBJECT">*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj</Item>
-			<Item Name="[value]" Condition="type == Variant::DICTIONARY">*(Dictionary *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::ARRAY">*(Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR4_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array</Item>
-
-		</Expand>
-	</Type>
-
-	<Type Name="String">
-		<DisplayString Condition="_cowdata._ptr == 0">[empty]</DisplayString>
-		<DisplayString Condition="_cowdata._ptr != 0">{_cowdata._ptr,s32}</DisplayString>
-		<StringView Condition="_cowdata._ptr != 0">_cowdata._ptr,s32</StringView>
-	</Type>
-
 	<Type Name="godot::String">
 		<DisplayString>{*reinterpret_cast&lt;void**&gt;(opaque),s32}</DisplayString>
 		<Expand>
@@ -250,13 +8,6 @@
 		</Expand>
 	</Type>
 
-	<Type Name="StringName">
-		<DisplayString Condition="_data">{_data->name,s32}</DisplayString>
-		<DisplayString Condition="!_data">[empty]</DisplayString>
-		<StringView Condition="_data">_data->name,s32</StringView>
-	</Type>
-
-	<!-- can't cast the opaque to ::StringName because Natvis does not support global namespace specifier? -->
 	<Type Name="godot::StringName">
 		<Intrinsic Name="get_data_ptr" Expression="(*reinterpret_cast&lt;const char32_t***&gt;(opaque))[1]" />
 		<DisplayString Condition="get_data_ptr()">{get_data_ptr(),s32}</DisplayString>
@@ -266,170 +17,122 @@
 		</Expand>
 	</Type>
 
-	<Type Name="Object::SignalData">
-		<DisplayString Condition="user.name._cowdata._ptr">"{user.name}" {slot_map}</DisplayString>
-		<DisplayString Condition="!user.name._cowdata._ptr">"{slot_map}</DisplayString>
-	</Type>
+	<!-- Development notes: there is no way to just ask AI to generate natvis entry for each `godot::` type
+	Each type required evaluation with LLDB console
+	The testdata used for evaluation https://github.com/JetBrains/godot-support/wiki/Developing-godot%E2%80%90cpp.natvis
+	The change of the memory layout would require adjustments of the natvis
+	-->
 
-	<Type Name="Vector2">
-		<DisplayString>({x,g}, {y,g})</DisplayString>
+	<!-- opaque[0..7] holds ArrayPrivate*. Dereference as unsigned long long* to read ArrayPrivate
+	     fields as 8-byte slots: [0]=refcount, [1]=unknown, [2]=_cowdata._ptr, [3]=read_only, ...
+	     Index [2] reaches _cowdata._ptr at offset +16 (verified by LLDB memory dump).
+	     Cast _ptr to unsigned long long* so [-1] reads the CowData element count 8 bytes before data. -->
+	<Type Name="godot::Array">
+		<Intrinsic Name="_cow" Expression="(unsigned long long*)(*reinterpret_cast&lt;unsigned long long**&gt;(opaque))[2]" />
+		<DisplayString Condition="!*reinterpret_cast&lt;void**&gt;(opaque) || !_cow()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_cow()[-1]}}}</DisplayString>
 		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-		</Expand>
-	</Type>
-	<Type Name="Vector2i">
-		<DisplayString>({x}, {y})</DisplayString>
-		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Vector3">
-		<DisplayString>({x,g}, {y,g}, {z,g})</DisplayString>
-		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-			<Item Name="[z]">z</Item>
-		</Expand>
-	</Type>
-	<Type Name="Vector3i">
-		<DisplayString>({x}, {y}, {z})</DisplayString>
-		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-			<Item Name="[z]">z</Item>
+			<Item Name="[size]">_cow()[-1]</Item>
+			<ArrayItems>
+				<Size>_cow()[-1]</Size>
+				<ValuePointer>(godot::Variant*)_cow()</ValuePointer>
+			</ArrayItems>
 		</Expand>
 	</Type>
 
-	<Type Name="Vector4">
-		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
+	<!-- DictionaryPrivate layout (verified by LLDB console):
+	     [refcount(4)][unknown(4)][read_only(8)][HashMap at +16]
+	     HashMap: [_elements(8)][unknown(8)][_head(8)][_last(8)][_capacity_index(4)][_num_elements(4)]
+	     HashMapElement: [next(8)][prev(8)][key:Variant(24)][value:Variant(24)] -->
+	<Type Name="godot::Dictionary">
+		<Intrinsic Name="_p"    Expression="*reinterpret_cast&lt;unsigned char**&gt;(opaque)" />
+		<Intrinsic Name="_size" Expression="*(unsigned int*)(_p() + 52)" />
+		<Intrinsic Name="_head" Expression="*reinterpret_cast&lt;unsigned char**&gt;(_p() + 32)" />
+		<DisplayString Condition="!_p()">{{empty}}</DisplayString>
+		<DisplayString>{{size={_size()}}}</DisplayString>
 		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-			<Item Name="[z]">z</Item>
-			<Item Name="[w]">w</Item>
-		</Expand>
-	</Type>
-	<Type Name="Vector4i">
-		<DisplayString>({x}, {y}, {z}, {w})</DisplayString>
-		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-			<Item Name="[z]">z</Item>
-			<Item Name="[w]">w</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Quaternion">
-		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
-		<Expand>
-			<Item Name="[x]">x</Item>
-			<Item Name="[y]">y</Item>
-			<Item Name="[z]">z</Item>
-			<Item Name="[w]">w</Item>
+			<Item Name="[size]">_size()</Item>
+			<CustomListItems MaxItemsPerView="5000">
+				<Variable Name="elem" InitialValue="(unsigned char*)_head()"/>
+				<Variable Name="idx"  InitialValue="0"/>
+				<Loop Condition="elem != 0">
+					<Item Name="[{idx}].key">*(godot::Variant*)(elem + 16)</Item>
+					<Item Name="[{idx}].value">*(godot::Variant*)(elem + 40)</Item>
+					<Exec>elem = *(unsigned char**)elem</Exec>
+					<Exec>idx++</Exec>
+				</Loop>
+			</CustomListItems>
 		</Expand>
 	</Type>
 
-	<Type Name="Color">
-		<DisplayString>({r,g}, {g,g}, {b,g}, {a,g})</DisplayString>
+	<!-- Variant::Type enum:
+	     NIL=0 BOOL=1 INT=2 FLOAT=3 STRING=4 VECTOR2=5 VECTOR2I=6 RECT2=7 RECT2I=8
+	     VECTOR3=9 VECTOR3I=10 TRANSFORM2D=11 VECTOR4=12 VECTOR4I=13 PLANE=14
+	     QUATERNION=15 AABB=16 BASIS=17 TRANSFORM3D=18 PROJECTION=19 COLOR=20
+	     STRING_NAME=21 NODE_PATH=22 RID=23 OBJECT=24 CALLABLE=25 SIGNAL=26
+	     DICTIONARY=27 ARRAY=28
+	     Layout: opaque[0..3]=type(int32), opaque[4..7]=pad, opaque[8..23]=_data union -->
+	<Type Name="godot::Variant">
+		<Intrinsic Name="_type" Expression="*reinterpret_cast&lt;int*&gt;(opaque)" />
+		<DisplayString Condition="_type() == 0">nil</DisplayString>
+		<DisplayString Condition="_type() == 1">{*reinterpret_cast&lt;bool*&gt;(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 2">{*reinterpret_cast&lt;long long*&gt;(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 3">{*reinterpret_cast&lt;double*&gt;(opaque+8)}</DisplayString>
+		<!-- inline types: stored directly in _data._mem at opaque+8 -->
+		<DisplayString Condition="_type() == 4">{*(godot::String*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 5">{*(godot::Vector2*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 6">{*(godot::Vector2i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 7">{*(godot::Rect2*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 8">{*(godot::Rect2i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 9">{*(godot::Vector3*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 10">{*(godot::Vector3i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 12">{*(godot::Vector4*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 13">{*(godot::Vector4i*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 14">{*(godot::Plane*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 15">{*(godot::Quaternion*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 20">{*(godot::Color*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 21">{*(godot::StringName*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 22">{*(godot::NodePath*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 23">{*(godot::RID*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 25">{*(godot::Callable*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 26">{*(godot::Signal*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 27">{*(godot::Dictionary*)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 28">{*(godot::Array*)(opaque+8)}</DisplayString>
+		<!-- heap-allocated types: opaque+8 holds a pointer, double-deref required -->
+		<DisplayString Condition="_type() == 11">{**(godot::Transform2D**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 16">{**(godot::AABB**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 17">{**(godot::Basis**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 18">{**(godot::Transform3D**)(opaque+8)}</DisplayString>
+		<DisplayString Condition="_type() == 19">{**(godot::Projection**)(opaque+8)}</DisplayString>
+		<!-- OBJECT: opaque+8=ObjectID, opaque+16=Object* -->
+		<DisplayString Condition="_type() == 24">Object(id={*reinterpret_cast&lt;unsigned long long*&gt;(opaque+8)})</DisplayString>
+		<DisplayString>{{type={_type()}}}</DisplayString>
 		<Expand>
-			<Item Name="[red]">r</Item>
-			<Item Name="[green]">g</Item>
-			<Item Name="[blue]">b</Item>
-			<Item Name="[alpha]">a</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Rect2">
-		<DisplayString>[P: {position}, S: {size}]</DisplayString>
-		<Expand>
-			<Item Name="[position]">position,nr</Item>
-			<Item Name="[size]">size,nr</Item>
-		</Expand>
-	</Type>
-	<Type Name="Rect2i">
-		<DisplayString>[P: {position}, S: {size}]</DisplayString>
-		<Expand>
-			<Item Name="[position]">position,nr</Item>
-			<Item Name="[size]">size,nr</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="AABB">
-		<DisplayString>[P: {position}, S: {size}]</DisplayString>
-		<Expand>
-			<Item Name="[position]">position,nr</Item>
-			<Item Name="[size]">size,nr</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Plane">
-		<DisplayString>[N: {normal}, D: {d,g}]</DisplayString>
-		<Expand>
-			<Item Name="[normal]">normal,nr</Item>
-			<Item Name="[d]">d</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Basis">
-		<DisplayString>[X: {rows[0]}, Y: {rows[1]}, Z: {rows[2]}]</DisplayString>
-		<Expand>
-			<Item Name="[x]">rows[0],nr</Item>
-			<Item Name="[y]">rows[1],nr</Item>
-			<Item Name="[z]">rows[2],nr</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Transform2D">
-		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, O: {columns[2]}]</DisplayString>
-		<Expand>
-			<Item Name="[x]">columns[0],nr</Item>
-			<Item Name="[y]">columns[1],nr</Item>
-			<Item Name="[origin]">columns[2],nr</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Transform3D">
-		<!-- Can't call column functions, so just pretend we can via obscene code duplication. -->
-		<DisplayString>[X: ({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g}), Y: ({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g}), Z: ({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g}), O: {origin}]</DisplayString>
-		<Expand>
-			<Synthetic Name="[x]">
-				<DisplayString>({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g})</DisplayString>
-				<Expand>
-					<Item Name="[x]">basis.rows[0].x</Item>
-					<Item Name="[y]">basis.rows[1].x</Item>
-					<Item Name="[z]">basis.rows[2].x</Item>
-				</Expand>
-			</Synthetic>
-			<Synthetic Name="[y]">
-				<DisplayString>({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g})</DisplayString>
-				<Expand>
-					<Item Name="[x]">basis.rows[0].y</Item>
-					<Item Name="[y]">basis.rows[1].y</Item>
-					<Item Name="[z]">basis.rows[2].y</Item>
-				</Expand>
-			</Synthetic>
-			<Synthetic Name="[z]">
-				<DisplayString>({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g})</DisplayString>
-				<Expand>
-					<Item Name="[x]">basis.rows[0].z</Item>
-					<Item Name="[y]">basis.rows[1].z</Item>
-					<Item Name="[z]">basis.rows[2].z</Item>
-				</Expand>
-			</Synthetic>
-			<Item Name="[origin]">origin,nr</Item>
-		</Expand>
-	</Type>
-
-	<Type Name="Projection">
-		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, Z: {columns[2]}, W: {columns[3]}]</DisplayString>
-		<Expand>
-			<Item Name="[x]">columns[0],nr</Item>
-			<Item Name="[y]">columns[1],nr</Item>
-			<Item Name="[z]">columns[2],nr</Item>
-			<Item Name="[w]">columns[3],nr</Item>
+			<Item Name="[type]">_type()</Item>
+			<ExpandedItem Condition="_type() == 4">*(godot::String*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 5">*(godot::Vector2*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 6">*(godot::Vector2i*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 7">*(godot::Rect2*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 8">*(godot::Rect2i*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 9">*(godot::Vector3*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 10">*(godot::Vector3i*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 11">**(godot::Transform2D**)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 12">*(godot::Vector4*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 13">*(godot::Vector4i*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 14">*(godot::Plane*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 15">*(godot::Quaternion*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 16">**(godot::AABB**)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 17">**(godot::Basis**)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 18">**(godot::Transform3D**)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 19">**(godot::Projection**)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 20">*(godot::Color*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 21">*(godot::StringName*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 22">*(godot::NodePath*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 23">*(godot::RID*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 25">*(godot::Callable*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 26">*(godot::Signal*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 27">*(godot::Dictionary*)(opaque+8)</ExpandedItem>
+			<ExpandedItem Condition="_type() == 28">*(godot::Array*)(opaque+8)</ExpandedItem>
 		</Expand>
 	</Type>
 </AutoVisualizer>


### PR DESCRIPTION
The original `godot.natvis` exists in the 
https://github.com/godotengine/godot/blob/master/platform/windows/godot.natvis
and only supported `godot::String` and the `godot::StringName` was added recently in https://github.com/godotengine/godot/pull/116955

Discussed in https://chat.godotengine.org/channel/gdextension?msg=mCgwe4cCkP3b43TjY
We realized there is no point in keeping godot-cpp type in the `godot.natvis` in the godotengine repo. All the types in godot-cpp are not the same - godot-cpp wraps the original godotengine types.

I have only tested the PR with JetBrians Rider. Just having the file, where it is located now is enough to automatically be used for debugging.

Related JetBrains tickets: https://youtrack.jetbrains.com/issue/RIDER-131718/Windows-Debug-GdExtension-from-Rider-usability, https://youtrack.jetbrains.com/issue/CPP-35297/Natvis-support-on-macOS-Linux-with-lldb

<img width="1500" height="1032" alt="image" src="https://github.com/user-attachments/assets/5507bff3-65ef-4ad7-a789-56a246511d7f" />
