### PR TITLE
Replace `pre-commit` with `prek`

### DIFF
--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -35,7 +35,7 @@ jobs:
           - name: 🐧 Linux (GCC) for Godot 4.6
             os: ubuntu-22.04
             platform: linux
-            artifact-name: godot-cpp-linux-glibc2.27-x86_64-release-godot45
+            artifact-name: godot-cpp-linux-glibc2.27-x86_64-release-godot46
             artifact-path: bin/libgodot-cpp.linux.template_release.x86_64.a
             run-tests: true
             api-version: 4.6

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -20,11 +20,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v45
 
-      - name: Style checks via pre-commit
-        uses: pre-commit/action@v3.0.1
+      - name: Style checks via prek
+        uses: j178/prek-action@v2
         with:
-          extra_args: --verbose --hook-stage manual --files ${{ steps.changed-files.outputs.all_changed_files }}
-
-      - name: Check generated files consistency
-        run:
-          python misc/scripts/check_get_file_list.py
+          extra-args: --verbose --hook-stage manual --files ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
- See: godotengine/godot#119150

Drop-in replacement for pre-commit that operates much faster & opens the door to functionality not possible before. Already implemented in the main repo & the speedup has measurably improved the CI workflow