### PR TITLE
Require hot reload to be explicitly enabled

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -315,7 +315,7 @@ function(godotcpp_generate)
     godot_arch_name( ARCH_NAME )
 
     # Transform options into generator expressions
-    set(HOT_RELOAD-UNSET "$<STREQUAL:${GODOTCPP_USE_HOT_RELOAD},>")
+    set(HOT_RELOAD "$<BOOL:${GODOTCPP_USE_HOT_RELOAD}>")
 
     set(DISABLE_EXCEPTIONS "$<BOOL:${GODOTCPP_DISABLE_EXCEPTIONS}>")
 
@@ -337,7 +337,6 @@ function(godotcpp_generate)
     ### Define our godot-cpp library targets
     # Generator Expressions that rely on the target
     set(DEBUG_FEATURES "$<NOT:$<STREQUAL:${GODOTCPP_TARGET},template_release>>")
-    set(HOT_RELOAD "$<IF:${HOT_RELOAD-UNSET},${DEBUG_FEATURES},$<BOOL:${GODOTCPP_USE_HOT_RELOAD}>>")
 
     # Suffix Generator Expression
     string(

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -15,12 +15,12 @@ function(linux_options)
         the docs (https://docs.godotengine.org/en/latest/tutorials/scripting/cpp/build_system/cmake.html)
         for examples.
     ]]
-    option(GODOTCPP_USE_STATIC_CPP "Link libgcc and libstdc++ statically for better portability" OFF)
+    option(GODOTCPP_USE_STATIC_CPP "Link libgcc and libstdc++ statically for better portability" ON)
 endfunction()
 
 #[===========================[ Target Generation ]===========================]
 function(linux_generate)
-    set(STATIC_CPP "$<BOOL:${GODOTCPP_USE_STATIC_CPP}>")
+    set(STATIC_CPP "$<AND:$<BOOL:${GODOTCPP_USE_STATIC_CPP}>,$<NOT:${HOT_RELOAD}>>")
 
     target_compile_definitions(godot-cpp PUBLIC LINUX_ENABLED UNIX_ENABLED)
 

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -359,7 +359,7 @@ def options(opts, env):
         BoolVariable(
             key="use_hot_reload",
             help="Enable the extra accounting required to support hot reload.",
-            default=env.get("use_hot_reload", None),
+            default=env.get("use_hot_reload", False),
         )
     )
 
@@ -454,7 +454,7 @@ def generate(env):
     print("Building for architecture " + env["arch"] + " on platform " + env["platform"])
 
     # These defaults may be needed by platform tools
-    env.use_hot_reload = env.get("use_hot_reload", env["target"] != "template_release")
+    env.use_hot_reload = env["use_hot_reload"]
     env.editor_build = env["target"] == "editor"
     env.dev_build = env["dev_build"]
     env.debug_features = env["target"] in ["editor", "template_debug"]

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -5,7 +5,7 @@ from SCons.Variables import BoolVariable
 
 def options(opts):
     opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler - only effective when targeting Linux", False))
-    opts.Add(BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", False))
+    opts.Add(BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True))
 
 
 def exists(env):
@@ -19,6 +19,10 @@ def generate(env):
     elif env.use_hot_reload:
         # Required for extensions to truly unload.
         env.Append(CXXFLAGS=["-fno-gnu-unique"])
+
+    if env.use_hot_reload:
+        # Reload won't work with "use_static_cpp", so disable it.
+        env["use_static_cpp"] = False
 
     env.Append(CCFLAGS=["-fPIC", "-Wwrite-strings"])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])


### PR DESCRIPTION
Currently, hot reload is enabled by default on debug builds, however, I've since wished we didn't enable it by default and required developers to opt-in

This was discussed on https://github.com/godotengine/godot-cpp/issues/1876, where we could have done something better if hot reload was opt-in, but I didn't want the potentially disruptive change

However, now that we're about to release v10, maybe now is the time to do this? It will no longer be as disruptive, because it would be associated with a versioned release that can be documented as an upgrading note

Per https://github.com/godotengine/godot-cpp/issues/1876, this also rolls back the changes from https://github.com/godotengine/godot-cpp/pull/1878 and includes the changes from https://github.com/godotengine/godot-cpp/pull/1877, which I think is the better solution

## AI disclosure

I used Claude code for the CMake changes, because I really don't know CMake very well. However, I did test the changes with various options and they seem to work as intended! Human review would be much appreciated (cc @enetheru)