### PR TITLE
Fix missing namespaces in macros

### DIFF
--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -148,7 +148,7 @@ public:
 	_ALWAYS_INLINE_ void delete_allocation(T *p_allocation) { memdelete(p_allocation); }
 };
 
-#define memnew_arr(m_class, m_count) memnew_arr_template<m_class>(m_count)
+#define memnew_arr(m_class, m_count) ::godot::memnew_arr_template<m_class>(m_count)
 
 _FORCE_INLINE_ uint64_t *_get_element_count_ptr(uint8_t *p_ptr) {
 	return (uint64_t *)(p_ptr - Memory::DATA_OFFSET + Memory::ELEMENT_OFFSET);

--- a/include/godot_cpp/templates/safe_refcount.hpp
+++ b/include/godot_cpp/templates/safe_refcount.hpp
@@ -48,13 +48,13 @@ namespace godot {
 //   even with threads that are already running.
 
 // These are used in very specific areas of the engine where it's critical that these guarantees are held
-#define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type)                    \
-	static_assert(sizeof(SafeNumeric<m_type>) == sizeof(m_type));   \
-	static_assert(alignof(SafeNumeric<m_type>) == alignof(m_type)); \
+#define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type)                             \
+	static_assert(sizeof(::godot::SafeNumeric<m_type>) == sizeof(m_type));   \
+	static_assert(alignof(::godot::SafeNumeric<m_type>) == alignof(m_type)); \
 	static_assert(std::is_trivially_destructible_v<std::atomic<m_type>>);
-#define SAFE_FLAG_TYPE_PUN_GUARANTEES                \
-	static_assert(sizeof(SafeFlag) == sizeof(bool)); \
-	static_assert(alignof(SafeFlag) == alignof(bool));
+#define SAFE_FLAG_TYPE_PUN_GUARANTEES                         \
+	static_assert(sizeof(::godot::SafeFlag) == sizeof(bool)); \
+	static_assert(alignof(::godot::SafeFlag) == alignof(bool));
 
 template <typename T>
 class SafeNumeric {


### PR DESCRIPTION
Changed the method call to `memnew_arr_template` in the `memnew_arr` and the classes in the size validation macros for `SafeNumeric` and `SafeFlag` to use the full namespace path to their corresponding method / class. This ensures that if anyone is using these macros in their own code and they don't use `using namespace godot;` in their code, these macros will still compile. 

`memnew_arr` was the issue I initially ran into, and I came across the `SafeNumeric` and `SafeFlag` macros while checking to see if any other macros had this problem. I also found the `MAKE_TYPE_INFO*` macros in [type_info.hpp](https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/type_info.hpp), as well as `MAKE_TYPED_ARRAY` and `MAKE_TYPED_DICTIONARY*` in [typed_array.hpp](https://github.com/godotengine/godot-cpp/blob/6c9ee5d7ea2d94051968c4c048309eb6b3b04b5d/include/godot_cpp/variant/typed_array.hpp) and [typed_dictionary.hpp](https://github.com/godotengine/godot-cpp/blob/6c9ee5d7ea2d94051968c4c048309eb6b3b04b5d/include/godot_cpp/variant/typed_dictionary.hpp) respectively, however, these seemed to be internal macros only, so I've left them untouched since I didn't think anyone would be using these in their own projects (I thought that it might be possible for the `SafeNumeric` and `SafeFlag` macros to appear in other projects though, which is why I included them).