### PR TITLE
Don't right-align escaped newlines, e.g. for `#define`.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,7 +34,7 @@ AlignAfterOpenBracket: DontAlign
 #   AcrossEmptyLines: false
 #   AcrossComments: false
 #   AlignCaseColons: false
-# AlignEscapedNewlines: Right
+AlignEscapedNewlines: DontAlign # Aligning leads to long diffs
 AlignOperands: DontAlign
 AlignTrailingComments:
   Kind: Never

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,6 @@
 
 # Style: Replace header guards with `#pragma once`
 7056c996dd43ae1aa466c94d95cc2fe63853d8a9
+
+# Style: Don't right-align escaped newlines
+7465a586dcdcc19dc30958f4ddfde92b3e80d6bc

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -178,324 +178,324 @@ struct EngineClassRegistration {
 // Use this on top of your own classes.
 // Note: the trail of `***` is to keep sane diffs in PRs, because clang-format otherwise moves every `\` which makes
 // every line of the macro different
-#define GDCLASS(m_class, m_inherits) /***********************************************************************************************************************************************/ \
-private:                                                                                                                                                                               \
-	void operator=(const m_class & /*p_rval*/) {}                                                                                                                                      \
-	friend class ::godot::ClassDB;                                                                                                                                                     \
-	friend class ::godot::Wrapped;                                                                                                                                                     \
-                                                                                                                                                                                       \
-protected:                                                                                                                                                                             \
-	virtual bool _is_extension_class() const override {                                                                                                                                \
-		return true;                                                                                                                                                                   \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static const ::godot::StringName *_get_extension_class_name() {                                                                                                                    \
-		const ::godot::StringName &string_name = get_class_static();                                                                                                                   \
-		return &string_name;                                                                                                                                                           \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (*_get_bind_methods())() {                                                                                                                                             \
-		return &m_class::_bind_methods;                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (::godot::Wrapped::*_get_notification())(int) {                                                                                                                        \
-		return (void (::godot::Wrapped::*)(int)) & m_class::_notification;                                                                                                             \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (::godot::Wrapped::*_get_set())(const ::godot::StringName &p_name, const ::godot::Variant &p_property) {                                                               \
-		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name, const ::godot::Variant &p_property)) & m_class::_set;                                                    \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (::godot::Wrapped::*_get_get())(const ::godot::StringName &p_name, ::godot::Variant &r_ret) const {                                                                    \
-		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name, ::godot::Variant &r_ret) const) & m_class::_get;                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (::godot::Wrapped::*_get_get_property_list())(::godot::List<::godot::PropertyInfo> * p_list) const {                                                                   \
-		return (void (::godot::Wrapped::*)(::godot::List<::godot::PropertyInfo> * p_list) const) & m_class::_get_property_list;                                                        \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (::godot::Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) const {                                                                             \
-		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name) const) & m_class::_property_can_revert;                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (::godot::Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, ::godot::Variant &) const {                                                         \
-		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name, ::godot::Variant &) const) & m_class::_property_get_revert;                                              \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (::godot::Wrapped::*_get_validate_property())(::godot::PropertyInfo & p_property) const {                                                                              \
-		return (void (::godot::Wrapped::*)(::godot::PropertyInfo & p_property) const) & m_class::_validate_property;                                                                   \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static ::godot::String (::godot::Wrapped::*_get_to_string())() const {                                                                                                             \
-		return (::godot::String (::godot::Wrapped::*)() const) & m_class::_to_string;                                                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	template <typename T, typename B>                                                                                                                                                  \
-	static void register_virtuals() {                                                                                                                                                  \
-		m_inherits::register_virtuals<T, B>();                                                                                                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-public:                                                                                                                                                                                \
-	typedef m_class self_type;                                                                                                                                                         \
-	typedef m_inherits parent_type;                                                                                                                                                    \
-                                                                                                                                                                                       \
-	static void initialize_class() {                                                                                                                                                   \
-		static bool initialized = false;                                                                                                                                               \
-		if (initialized) {                                                                                                                                                             \
-			return;                                                                                                                                                                    \
-		}                                                                                                                                                                              \
-		m_inherits::initialize_class();                                                                                                                                                \
-		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                                                                         \
-			_bind_methods();                                                                                                                                                           \
-			m_inherits::register_virtuals<m_class, m_inherits>();                                                                                                                      \
-		}                                                                                                                                                                              \
-		initialized = true;                                                                                                                                                            \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static const ::godot::StringName &get_class_static() {                                                                                                                             \
-		static const ::godot::StringName string_name = ::godot::StringName(U## #m_class);                                                                                              \
-		return string_name;                                                                                                                                                            \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static const ::godot::StringName &get_parent_class_static() {                                                                                                                      \
-		return m_inherits::get_class_static();                                                                                                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void notification_bind(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed) {                                                                \
-		if (p_instance && m_class::_get_notification()) {                                                                                                                              \
-			if (!p_reversed) {                                                                                                                                                         \
-				m_inherits::notification_bind(p_instance, p_what, p_reversed);                                                                                                         \
-			}                                                                                                                                                                          \
-			if (m_class::_get_notification() != m_inherits::_get_notification()) {                                                                                                     \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				cls->_notification(p_what);                                                                                                                                            \
-			}                                                                                                                                                                          \
-			if (p_reversed) {                                                                                                                                                          \
-				m_inherits::notification_bind(p_instance, p_what, p_reversed);                                                                                                         \
-			}                                                                                                                                                                          \
-		}                                                                                                                                                                              \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionBool set_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value) {                                \
-		if (p_instance) {                                                                                                                                                              \
-			if (m_inherits::set_bind(p_instance, p_name, p_value)) {                                                                                                                   \
-				return true;                                                                                                                                                           \
-			}                                                                                                                                                                          \
-			if (m_class::_get_set() != m_inherits::_get_set()) {                                                                                                                       \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				return cls->_set(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<const ::godot::Variant *>(p_value));                                        \
-			}                                                                                                                                                                          \
-		}                                                                                                                                                                              \
-		return false;                                                                                                                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionBool get_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) {                                       \
-		if (p_instance) {                                                                                                                                                              \
-			if (m_inherits::get_bind(p_instance, p_name, r_ret)) {                                                                                                                     \
-				return true;                                                                                                                                                           \
-			}                                                                                                                                                                          \
-			if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                                                       \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				return cls->_get(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret));                                                \
-			}                                                                                                                                                                          \
-		}                                                                                                                                                                              \
-		return false;                                                                                                                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static inline bool has_get_property_list() {                                                                                                                                       \
-		return m_class::_get_get_property_list() && m_class::_get_get_property_list() != m_inherits::_get_get_property_list();                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static const GDExtensionPropertyInfo *get_property_list_bind(GDExtensionClassInstancePtr p_instance, uint32_t *r_count) {                                                          \
-		if (!p_instance) {                                                                                                                                                             \
-			if (r_count)                                                                                                                                                               \
-				*r_count = 0;                                                                                                                                                          \
-			return nullptr;                                                                                                                                                            \
-		}                                                                                                                                                                              \
-		m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                        \
-		::godot::List<::godot::PropertyInfo> *plist_cpp = memnew(::godot::List<::godot::PropertyInfo>);                                                                                \
-		cls->_get_property_list(plist_cpp);                                                                                                                                            \
-		return ::godot::internal::create_c_property_list(plist_cpp, r_count);                                                                                                          \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void free_property_list_bind(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t /*p_count*/) {                                         \
-		if (p_instance) {                                                                                                                                                              \
-			::godot::internal::free_c_property_list(const_cast<GDExtensionPropertyInfo *>(p_list));                                                                                    \
-		}                                                                                                                                                                              \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionBool property_can_revert_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name) {                                                    \
-		if (p_instance && m_class::_get_property_can_revert()) {                                                                                                                       \
-			if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) {                                                                                       \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				return cls->_property_can_revert(*reinterpret_cast<const ::godot::StringName *>(p_name));                                                                              \
-			}                                                                                                                                                                          \
-			return m_inherits::property_can_revert_bind(p_instance, p_name);                                                                                                           \
-		}                                                                                                                                                                              \
-		return false;                                                                                                                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionBool property_get_revert_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) {                       \
-		if (p_instance && m_class::_get_property_get_revert()) {                                                                                                                       \
-			if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) {                                                                                       \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				return cls->_property_get_revert(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret));                                \
-			}                                                                                                                                                                          \
-			return m_inherits::property_get_revert_bind(p_instance, p_name, r_ret);                                                                                                    \
-		}                                                                                                                                                                              \
-		return false;                                                                                                                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionBool validate_property_bind(GDExtensionClassInstancePtr p_instance, GDExtensionPropertyInfo *p_property) {                                                       \
-		bool ret = false;                                                                                                                                                              \
-		if (p_instance && m_class::_get_validate_property()) {                                                                                                                         \
-			ret = m_inherits::validate_property_bind(p_instance, p_property);                                                                                                          \
-			if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) {                                                                                           \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				::godot::PropertyInfo info(p_property);                                                                                                                                \
-				cls->_validate_property(info);                                                                                                                                         \
-				info._update(p_property);                                                                                                                                              \
-				return true;                                                                                                                                                           \
-			}                                                                                                                                                                          \
-		}                                                                                                                                                                              \
-		return ret;                                                                                                                                                                    \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void to_string_bind(GDExtensionClassInstancePtr p_instance, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out) {                                                      \
-		if (p_instance && m_class::_get_to_string()) {                                                                                                                                 \
-			if (m_class::_get_to_string() != m_inherits::_get_to_string()) {                                                                                                           \
-				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				*reinterpret_cast<::godot::String *>(r_out) = cls->_to_string();                                                                                                       \
-				*r_is_valid = true;                                                                                                                                                    \
-				return;                                                                                                                                                                \
-			}                                                                                                                                                                          \
-			m_inherits::to_string_bind(p_instance, r_is_valid, r_out);                                                                                                                 \
-		}                                                                                                                                                                              \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void free(void * /*data*/, GDExtensionClassInstancePtr ptr) {                                                                                                               \
-		if (ptr) {                                                                                                                                                                     \
-			m_class *cls = reinterpret_cast<m_class *>(ptr);                                                                                                                           \
-			cls->~m_class();                                                                                                                                                           \
-			::godot::Memory::free_static(cls);                                                                                                                                         \
-		}                                                                                                                                                                              \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void *_gde_binding_create_callback(void * /*p_token*/, void * /*p_instance*/) {                                                                                             \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void _gde_binding_free_callback(void * /*p_token*/, void * /*p_instance*/, void * /*p_binding*/) {                                                                          \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionBool _gde_binding_reference_callback(void * /*p_token*/, void * /*p_instance*/, GDExtensionBool /*p_reference*/) {                                               \
-		return true;                                                                                                                                                                   \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = {                                                                                                    \
-		_gde_binding_create_callback,                                                                                                                                                  \
-		_gde_binding_free_callback,                                                                                                                                                    \
-		_gde_binding_reference_callback,                                                                                                                                               \
-	};                                                                                                                                                                                 \
-                                                                                                                                                                                       \
-protected:                                                                                                                                                                             \
-	virtual void _notificationv(int32_t p_what, bool p_reversed = false) override {                                                                                                    \
-		m_class::notification_bind(this, p_what, p_reversed);                                                                                                                          \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
+#define GDCLASS(m_class, m_inherits) \
+private: \
+	void operator=(const m_class & /*p_rval*/) {} \
+	friend class ::godot::ClassDB; \
+	friend class ::godot::Wrapped; \
+\
+protected: \
+	virtual bool _is_extension_class() const override { \
+		return true; \
+	} \
+\
+	static const ::godot::StringName *_get_extension_class_name() { \
+		const ::godot::StringName &string_name = get_class_static(); \
+		return &string_name; \
+	} \
+\
+	static void (*_get_bind_methods())() { \
+		return &m_class::_bind_methods; \
+	} \
+\
+	static void (::godot::Wrapped::*_get_notification())(int) { \
+		return (void (::godot::Wrapped::*)(int)) & m_class::_notification; \
+	} \
+\
+	static bool (::godot::Wrapped::*_get_set())(const ::godot::StringName &p_name, const ::godot::Variant &p_property) { \
+		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name, const ::godot::Variant &p_property)) & m_class::_set; \
+	} \
+\
+	static bool (::godot::Wrapped::*_get_get())(const ::godot::StringName &p_name, ::godot::Variant &r_ret) const { \
+		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name, ::godot::Variant &r_ret) const) & m_class::_get; \
+	} \
+\
+	static void (::godot::Wrapped::*_get_get_property_list())(::godot::List<::godot::PropertyInfo> * p_list) const { \
+		return (void (::godot::Wrapped::*)(::godot::List<::godot::PropertyInfo> * p_list) const) & m_class::_get_property_list; \
+	} \
+\
+	static bool (::godot::Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) const { \
+		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name) const) & m_class::_property_can_revert; \
+	} \
+\
+	static bool (::godot::Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, ::godot::Variant &) const { \
+		return (bool (::godot::Wrapped::*)(const ::godot::StringName &p_name, ::godot::Variant &) const) & m_class::_property_get_revert; \
+	} \
+\
+	static void (::godot::Wrapped::*_get_validate_property())(::godot::PropertyInfo & p_property) const { \
+		return (void (::godot::Wrapped::*)(::godot::PropertyInfo & p_property) const) & m_class::_validate_property; \
+	} \
+\
+	static ::godot::String (::godot::Wrapped::*_get_to_string())() const { \
+		return (::godot::String (::godot::Wrapped::*)() const) & m_class::_to_string; \
+	} \
+\
+	template <typename T, typename B> \
+	static void register_virtuals() { \
+		m_inherits::register_virtuals<T, B>(); \
+	} \
+\
+public: \
+	typedef m_class self_type; \
+	typedef m_inherits parent_type; \
+\
+	static void initialize_class() { \
+		static bool initialized = false; \
+		if (initialized) { \
+			return; \
+		} \
+		m_inherits::initialize_class(); \
+		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) { \
+			_bind_methods(); \
+			m_inherits::register_virtuals<m_class, m_inherits>(); \
+		} \
+		initialized = true; \
+	} \
+\
+	static const ::godot::StringName &get_class_static() { \
+		static const ::godot::StringName string_name = ::godot::StringName(U## #m_class); \
+		return string_name; \
+	} \
+\
+	static const ::godot::StringName &get_parent_class_static() { \
+		return m_inherits::get_class_static(); \
+	} \
+\
+	static void notification_bind(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed) { \
+		if (p_instance && m_class::_get_notification()) { \
+			if (!p_reversed) { \
+				m_inherits::notification_bind(p_instance, p_what, p_reversed); \
+			} \
+			if (m_class::_get_notification() != m_inherits::_get_notification()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				cls->_notification(p_what); \
+			} \
+			if (p_reversed) { \
+				m_inherits::notification_bind(p_instance, p_what, p_reversed); \
+			} \
+		} \
+	} \
+\
+	static GDExtensionBool set_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value) { \
+		if (p_instance) { \
+			if (m_inherits::set_bind(p_instance, p_name, p_value)) { \
+				return true; \
+			} \
+			if (m_class::_get_set() != m_inherits::_get_set()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				return cls->_set(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<const ::godot::Variant *>(p_value)); \
+			} \
+		} \
+		return false; \
+	} \
+\
+	static GDExtensionBool get_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) { \
+		if (p_instance) { \
+			if (m_inherits::get_bind(p_instance, p_name, r_ret)) { \
+				return true; \
+			} \
+			if (m_class::_get_get() != m_inherits::_get_get()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				return cls->_get(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret)); \
+			} \
+		} \
+		return false; \
+	} \
+\
+	static inline bool has_get_property_list() { \
+		return m_class::_get_get_property_list() && m_class::_get_get_property_list() != m_inherits::_get_get_property_list(); \
+	} \
+\
+	static const GDExtensionPropertyInfo *get_property_list_bind(GDExtensionClassInstancePtr p_instance, uint32_t *r_count) { \
+		if (!p_instance) { \
+			if (r_count) \
+				*r_count = 0; \
+			return nullptr; \
+		} \
+		m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+		::godot::List<::godot::PropertyInfo> *plist_cpp = memnew(::godot::List<::godot::PropertyInfo>); \
+		cls->_get_property_list(plist_cpp); \
+		return ::godot::internal::create_c_property_list(plist_cpp, r_count); \
+	} \
+\
+	static void free_property_list_bind(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t /*p_count*/) { \
+		if (p_instance) { \
+			::godot::internal::free_c_property_list(const_cast<GDExtensionPropertyInfo *>(p_list)); \
+		} \
+	} \
+\
+	static GDExtensionBool property_can_revert_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name) { \
+		if (p_instance && m_class::_get_property_can_revert()) { \
+			if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				return cls->_property_can_revert(*reinterpret_cast<const ::godot::StringName *>(p_name)); \
+			} \
+			return m_inherits::property_can_revert_bind(p_instance, p_name); \
+		} \
+		return false; \
+	} \
+\
+	static GDExtensionBool property_get_revert_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) { \
+		if (p_instance && m_class::_get_property_get_revert()) { \
+			if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				return cls->_property_get_revert(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret)); \
+			} \
+			return m_inherits::property_get_revert_bind(p_instance, p_name, r_ret); \
+		} \
+		return false; \
+	} \
+\
+	static GDExtensionBool validate_property_bind(GDExtensionClassInstancePtr p_instance, GDExtensionPropertyInfo *p_property) { \
+		bool ret = false; \
+		if (p_instance && m_class::_get_validate_property()) { \
+			ret = m_inherits::validate_property_bind(p_instance, p_property); \
+			if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				::godot::PropertyInfo info(p_property); \
+				cls->_validate_property(info); \
+				info._update(p_property); \
+				return true; \
+			} \
+		} \
+		return ret; \
+	} \
+\
+	static void to_string_bind(GDExtensionClassInstancePtr p_instance, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out) { \
+		if (p_instance && m_class::_get_to_string()) { \
+			if (m_class::_get_to_string() != m_inherits::_get_to_string()) { \
+				m_class *cls = reinterpret_cast<m_class *>(p_instance); \
+				*reinterpret_cast<::godot::String *>(r_out) = cls->_to_string(); \
+				*r_is_valid = true; \
+				return; \
+			} \
+			m_inherits::to_string_bind(p_instance, r_is_valid, r_out); \
+		} \
+	} \
+\
+	static void free(void * /*data*/, GDExtensionClassInstancePtr ptr) { \
+		if (ptr) { \
+			m_class *cls = reinterpret_cast<m_class *>(ptr); \
+			cls->~m_class(); \
+			::godot::Memory::free_static(cls); \
+		} \
+	} \
+\
+	static void *_gde_binding_create_callback(void * /*p_token*/, void * /*p_instance*/) { \
+		return nullptr; \
+	} \
+\
+	static void _gde_binding_free_callback(void * /*p_token*/, void * /*p_instance*/, void * /*p_binding*/) { \
+	} \
+\
+	static GDExtensionBool _gde_binding_reference_callback(void * /*p_token*/, void * /*p_instance*/, GDExtensionBool /*p_reference*/) { \
+		return true; \
+	} \
+\
+	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = { \
+		_gde_binding_create_callback, \
+		_gde_binding_free_callback, \
+		_gde_binding_reference_callback, \
+	}; \
+\
+protected: \
+	virtual void _notificationv(int32_t p_what, bool p_reversed = false) override { \
+		m_class::notification_bind(this, p_what, p_reversed); \
+	} \
+\
 private:
 
 // Don't use this for your classes, use GDCLASS() instead.
-#define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits) /******************************************************************************************************************/ \
-private:                                                                                                                                                                               \
-	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper;                                                                           \
-	void operator=(const m_class &p_rval) {}                                                                                                                                           \
-	friend class ::godot::ClassDB;                                                                                                                                                     \
-	friend class ::godot::Wrapped;                                                                                                                                                     \
-                                                                                                                                                                                       \
-protected:                                                                                                                                                                             \
-	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                                                                                                  \
-	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                                                                                               \
-                                                                                                                                                                                       \
-	static void _bind_methods() {}                                                                                                                                                     \
-                                                                                                                                                                                       \
-	static void (*_get_bind_methods())() {                                                                                                                                             \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (Wrapped::*_get_notification())(int) {                                                                                                                                 \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) {                                                                                 \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const {                                                                                      \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static inline bool has_get_property_list() {                                                                                                                                       \
-		return false;                                                                                                                                                                  \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const {                                                                                              \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) const {                                                                                      \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) const {                                                                           \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void (Wrapped::*_get_validate_property())(::godot::PropertyInfo & p_property) const {                                                                                       \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static String (Wrapped::*_get_to_string())() const {                                                                                                                               \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-public:                                                                                                                                                                                \
-	typedef m_class self_type;                                                                                                                                                         \
-	typedef m_inherits parent_type;                                                                                                                                                    \
-                                                                                                                                                                                       \
-	static void initialize_class() {}                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static const ::godot::StringName &get_class_static() {                                                                                                                             \
-		static const ::godot::StringName string_name = ::godot::StringName(#m_alias_for);                                                                                              \
-		return string_name;                                                                                                                                                            \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static const ::godot::StringName &get_parent_class_static() {                                                                                                                      \
-		return m_inherits::get_class_static();                                                                                                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                                                                                    \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static void *_gde_binding_create_callback(void *p_token, void *p_instance) {                                                                                                       \
-		/* Do not call memnew here, we don't want the post-initializer to be called */                                                                                                 \
-		return new ("", "") m_class((GodotObject *)p_instance);                                                                                                                        \
-	}                                                                                                                                                                                  \
-	static void _gde_binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                                         \
-		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                                                                                     \
-		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                                                                                            \
-		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                                                                                   \
-	}                                                                                                                                                                                  \
-	static GDExtensionBool _gde_binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) {                                                             \
-		return true;                                                                                                                                                                   \
-	}                                                                                                                                                                                  \
-	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = {                                                                                                    \
-		_gde_binding_create_callback,                                                                                                                                                  \
-		_gde_binding_free_callback,                                                                                                                                                    \
-		_gde_binding_reference_callback,                                                                                                                                               \
-	};                                                                                                                                                                                 \
-	m_class() : m_class(#m_alias_for) {}                                                                                                                                               \
-                                                                                                                                                                                       \
+#define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits) \
+private: \
+	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper; \
+	void operator=(const m_class &p_rval) {} \
+	friend class ::godot::ClassDB; \
+	friend class ::godot::Wrapped; \
+\
+protected: \
+	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {} \
+	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {} \
+\
+	static void _bind_methods() {} \
+\
+	static void (*_get_bind_methods())() { \
+		return nullptr; \
+	} \
+\
+	static void (Wrapped::*_get_notification())(int) { \
+		return nullptr; \
+	} \
+\
+	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) { \
+		return nullptr; \
+	} \
+\
+	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const { \
+		return nullptr; \
+	} \
+\
+	static inline bool has_get_property_list() { \
+		return false; \
+	} \
+\
+	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const { \
+		return nullptr; \
+	} \
+\
+	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) const { \
+		return nullptr; \
+	} \
+\
+	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) const { \
+		return nullptr; \
+	} \
+\
+	static void (Wrapped::*_get_validate_property())(::godot::PropertyInfo & p_property) const { \
+		return nullptr; \
+	} \
+\
+	static String (Wrapped::*_get_to_string())() const { \
+		return nullptr; \
+	} \
+\
+public: \
+	typedef m_class self_type; \
+	typedef m_inherits parent_type; \
+\
+	static void initialize_class() {} \
+\
+	static const ::godot::StringName &get_class_static() { \
+		static const ::godot::StringName string_name = ::godot::StringName(#m_alias_for); \
+		return string_name; \
+	} \
+\
+	static const ::godot::StringName &get_parent_class_static() { \
+		return m_inherits::get_class_static(); \
+	} \
+\
+	static void free(void *data, GDExtensionClassInstancePtr ptr) { \
+	} \
+\
+	static void *_gde_binding_create_callback(void *p_token, void *p_instance) { \
+		/* Do not call memnew here, we don't want the post-initializer to be called */ \
+		return new ("", "") m_class((GodotObject *)p_instance); \
+	} \
+	static void _gde_binding_free_callback(void *p_token, void *p_instance, void *p_binding) { \
+		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */ \
+		reinterpret_cast<m_class *>(p_binding)->~m_class(); \
+		Memory::free_static(reinterpret_cast<m_class *>(p_binding)); \
+	} \
+	static GDExtensionBool _gde_binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) { \
+		return true; \
+	} \
+	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = { \
+		_gde_binding_create_callback, \
+		_gde_binding_free_callback, \
+		_gde_binding_reference_callback, \
+	}; \
+	m_class() : m_class(#m_alias_for) {} \
+\
 private:
 
 // Don't use this for your classes, use GDCLASS() instead.

--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -40,46 +40,46 @@
 
 namespace godot {
 
-#define VARIANT_ENUM_CAST(m_enum)                                      \
-	namespace godot {                                                  \
-	MAKE_ENUM_TYPE_INFO(m_enum)                                        \
-	template <>                                                        \
-	struct VariantCaster<m_enum> {                                     \
-		static _FORCE_INLINE_ m_enum cast(const Variant &p_variant) {  \
-			return (m_enum)p_variant.operator int64_t();               \
-		}                                                              \
-	};                                                                 \
-	template <>                                                        \
-	struct PtrToArg<m_enum> {                                          \
-		_FORCE_INLINE_ static m_enum convert(const void *p_ptr) {      \
-			return m_enum(*reinterpret_cast<const int64_t *>(p_ptr));  \
-		}                                                              \
-		typedef int64_t EncodeT;                                       \
+#define VARIANT_ENUM_CAST(m_enum) \
+	namespace godot { \
+	MAKE_ENUM_TYPE_INFO(m_enum) \
+	template <> \
+	struct VariantCaster<m_enum> { \
+		static _FORCE_INLINE_ m_enum cast(const Variant &p_variant) { \
+			return (m_enum)p_variant.operator int64_t(); \
+		} \
+	}; \
+	template <> \
+	struct PtrToArg<m_enum> { \
+		_FORCE_INLINE_ static m_enum convert(const void *p_ptr) { \
+			return m_enum(*reinterpret_cast<const int64_t *>(p_ptr)); \
+		} \
+		typedef int64_t EncodeT; \
 		_FORCE_INLINE_ static void encode(m_enum p_val, void *p_ptr) { \
-			*reinterpret_cast<int64_t *>(p_ptr) = p_val;               \
-		}                                                              \
-	};                                                                 \
+			*reinterpret_cast<int64_t *>(p_ptr) = p_val; \
+		} \
+	}; \
 	}
 
-#define VARIANT_BITFIELD_CAST(m_enum)                                            \
-	namespace godot {                                                            \
-	MAKE_BITFIELD_TYPE_INFO(m_enum)                                              \
-	template <>                                                                  \
-	struct VariantCaster<BitField<m_enum>> {                                     \
-		static _FORCE_INLINE_ BitField<m_enum> cast(const Variant &p_variant) {  \
-			return BitField<m_enum>(p_variant.operator int64_t());               \
-		}                                                                        \
-	};                                                                           \
-	template <>                                                                  \
-	struct PtrToArg<BitField<m_enum>> {                                          \
-		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) {      \
-			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr));  \
-		}                                                                        \
-		typedef int64_t EncodeT;                                                 \
+#define VARIANT_BITFIELD_CAST(m_enum) \
+	namespace godot { \
+	MAKE_BITFIELD_TYPE_INFO(m_enum) \
+	template <> \
+	struct VariantCaster<BitField<m_enum>> { \
+		static _FORCE_INLINE_ BitField<m_enum> cast(const Variant &p_variant) { \
+			return BitField<m_enum>(p_variant.operator int64_t()); \
+		} \
+	}; \
+	template <> \
+	struct PtrToArg<BitField<m_enum>> { \
+		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) { \
+			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr)); \
+		} \
+		typedef int64_t EncodeT; \
 		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, void *p_ptr) { \
-			*reinterpret_cast<int64_t *>(p_ptr) = p_val;                         \
-		}                                                                        \
-	};                                                                           \
+			*reinterpret_cast<int64_t *>(p_ptr) = p_val; \
+		} \
+	}; \
 	}
 
 template <typename T>

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -226,12 +226,12 @@ public:
 #define BIND_BITFIELD_FLAG(m_constant) \
 	::godot::ClassDB::bind_integer_constant(get_class_static(), ::godot::_gde_constant_get_bitfield_name(m_constant, #m_constant), #m_constant, m_constant, true);
 
-#define BIND_VIRTUAL_METHOD(m_class, m_method, m_hash)                                                                                        \
-	{                                                                                                                                         \
+#define BIND_VIRTUAL_METHOD(m_class, m_method, m_hash) \
+	{ \
 		auto _call##m_method = [](GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr p_ret) -> void { \
-			call_with_ptr_args(reinterpret_cast<m_class *>(p_instance), &m_class::m_method, p_args, p_ret);                                   \
-		};                                                                                                                                    \
-		::godot::ClassDB::bind_virtual_method(m_class::get_class_static(), #m_method, _call##m_method, m_hash);                               \
+			call_with_ptr_args(reinterpret_cast<m_class *>(p_instance), &m_class::m_method, p_args, p_ret); \
+		}; \
+		::godot::ClassDB::bind_virtual_method(m_class::get_class_static(), #m_method, _call##m_method, m_hash); \
 	}
 
 template <typename T, bool is_abstract>

--- a/include/godot_cpp/core/error_macros.hpp
+++ b/include/godot_cpp/core/error_macros.hpp
@@ -96,32 +96,32 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns.
  */
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                                  \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                              \
+#define ERR_FAIL_INDEX(m_index, m_size) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                          \
-	} else                                                                                                               \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                              \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                     \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                                 \
-	} else                                                                                                                      \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                                  \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                           \
+#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                                       \
-	} else                                                                                                                            \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -131,32 +131,32 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                      \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                              \
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                                 \
-	} else                                                                                                               \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                  \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                     \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                                        \
-	} else                                                                                                                      \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                                      \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                           \
+#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                              \
-	} else                                                                                                                            \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -167,12 +167,12 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the application crashes.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                                  \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                               \
+#define CRASH_BAD_INDEX(m_index, m_size) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		::godot::_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                                  \
-	} else                                                                                                                                \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -182,12 +182,12 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                          \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                                  \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		::godot::_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                                     \
-	} else                                                                                                                                   \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 // Unsigned integer index out of bounds error macros.
@@ -199,32 +199,32 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) >= (m_size))) {                                                                               \
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                          \
-	} else                                                                                                               \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
-	if (unlikely((m_index) >= (m_size))) {                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                                 \
-	} else                                                                                                                      \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
-	if (unlikely((m_index) >= (m_size))) {                                                                                            \
+#define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                                       \
-	} else                                                                                                                            \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -234,32 +234,32 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) >= (m_size))) {                                                                               \
+#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                                 \
-	} else                                                                                                               \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
-	if (unlikely((m_index) >= (m_size))) {                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                                        \
-	} else                                                                                                                      \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_V_EDMSG` but also notifies the editor.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
-	if (unlikely((m_index) >= (m_size))) {                                                                                            \
+#define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                              \
-	} else                                                                                                                            \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -270,12 +270,12 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                         \
-	if (unlikely((m_index) >= (m_size))) {                                                                                                \
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		::godot::_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                                  \
-	} else                                                                                                                                \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -285,12 +285,12 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                 \
-	if (unlikely((m_index) >= (m_size))) {                                                                                                   \
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		::godot::_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                                     \
-	} else                                                                                                                                   \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 // Null reference error macros.
@@ -302,32 +302,32 @@ void _err_flush_stdout();
  * Ensures a pointer `m_param` is not null.
  * If it is null, the current function returns.
  */
-#define ERR_FAIL_NULL(m_param)                                                                                   \
-	if (unlikely(m_param == nullptr)) {                                                                          \
+#define ERR_FAIL_NULL(m_param) \
+	if (unlikely(m_param == nullptr)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return;                                                                                                  \
-	} else                                                                                                       \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                               \
-	if (unlikely(m_param == nullptr)) {                                                                                 \
+#define ERR_FAIL_NULL_MSG(m_param, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
-		return;                                                                                                         \
-	} else                                                                                                              \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_NULL_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_NULL_EDMSG(m_param, m_msg)                                                                                   \
-	if (unlikely(m_param == nullptr)) {                                                                                       \
+#define ERR_FAIL_NULL_EDMSG(m_param, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
-		return;                                                                                                               \
-	} else                                                                                                                    \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -337,32 +337,32 @@ void _err_flush_stdout();
  * Ensures a pointer `m_param` is not null.
  * If it is null, the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V(m_param, m_retval)                                                                       \
-	if (unlikely(m_param == nullptr)) {                                                                          \
+#define ERR_FAIL_NULL_V(m_param, m_retval) \
+	if (unlikely(m_param == nullptr)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return m_retval;                                                                                         \
-	} else                                                                                                       \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                   \
-	if (unlikely(m_param == nullptr)) {                                                                                 \
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
-		return m_retval;                                                                                                \
-	} else                                                                                                              \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_NULL_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg)                                                                       \
-	if (unlikely(m_param == nullptr)) {                                                                                       \
+#define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
-		return m_retval;                                                                                                      \
-	} else                                                                                                                    \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -374,11 +374,11 @@ void _err_flush_stdout();
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current function returns.
  */
-#define ERR_FAIL_COND(m_cond)                                                                                   \
-	if (unlikely(m_cond)) {                                                                                     \
+#define ERR_FAIL_COND(m_cond) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -388,21 +388,21 @@ void _err_flush_stdout();
  * If checking for null use ERR_FAIL_NULL_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
  */
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                               \
-	if (unlikely(m_cond)) {                                                                                            \
+#define ERR_FAIL_COND_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg); \
-		return;                                                                                                        \
-	} else                                                                                                             \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_COND_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_COND_EDMSG(m_cond, m_msg)                                                                                   \
-	if (unlikely(m_cond)) {                                                                                                  \
+#define ERR_FAIL_COND_EDMSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg, true); \
-		return;                                                                                                              \
-	} else                                                                                                                   \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -414,11 +414,11 @@ void _err_flush_stdout();
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current function returns `m_retval`.
  */
-#define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                                  \
-	if (unlikely(m_cond)) {                                                                                                                \
+#define ERR_FAIL_COND_V(m_cond, m_retval) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                                                   \
-	} else                                                                                                                                 \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -428,21 +428,21 @@ void _err_flush_stdout();
  * If checking for null use ERR_FAIL_NULL_V_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
  */
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                              \
-	if (unlikely(m_cond)) {                                                                                                                       \
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
-		return m_retval;                                                                                                                          \
-	} else                                                                                                                                        \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_COND_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg)                                                                                                  \
-	if (unlikely(m_cond)) {                                                                                                                             \
+#define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg, true); \
-		return m_retval;                                                                                                                                \
-	} else                                                                                                                                              \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -452,32 +452,32 @@ void _err_flush_stdout();
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current loop continues.
  */
-#define ERR_CONTINUE(m_cond)                                                                                                \
-	if (unlikely(m_cond)) {                                                                                                 \
+#define ERR_CONTINUE(m_cond) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-		continue;                                                                                                           \
-	} else                                                                                                                  \
+		continue; \
+	} else \
 		((void)0)
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop continues.
  */
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                            \
-	if (unlikely(m_cond)) {                                                                                                        \
+#define ERR_CONTINUE_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg); \
-		continue;                                                                                                                  \
-	} else                                                                                                                         \
+		continue; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_CONTINUE_MSG` but also notifies the editor.
  */
-#define ERR_CONTINUE_EDMSG(m_cond, m_msg)                                                                                                \
-	if (unlikely(m_cond)) {                                                                                                              \
+#define ERR_CONTINUE_EDMSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg, true); \
-		continue;                                                                                                                        \
-	} else                                                                                                                               \
+		continue; \
+	} else \
 		((void)0)
 
 /**
@@ -487,32 +487,32 @@ void _err_flush_stdout();
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current loop breaks.
  */
-#define ERR_BREAK(m_cond)                                                                                                 \
-	if (unlikely(m_cond)) {                                                                                               \
+#define ERR_BREAK(m_cond) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-		break;                                                                                                            \
-	} else                                                                                                                \
+		break; \
+	} else \
 		((void)0)
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop breaks.
  */
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                             \
-	if (unlikely(m_cond)) {                                                                                                      \
+#define ERR_BREAK_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg); \
-		break;                                                                                                                   \
-	} else                                                                                                                       \
+		break; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_BREAK_MSG` but also notifies the editor.
  */
-#define ERR_BREAK_EDMSG(m_cond, m_msg)                                                                                                 \
-	if (unlikely(m_cond)) {                                                                                                            \
+#define ERR_BREAK_EDMSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg, true); \
-		break;                                                                                                                         \
-	} else                                                                                                                             \
+		break; \
+	} else \
 		((void)0)
 
 /**
@@ -523,12 +523,12 @@ void _err_flush_stdout();
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the application crashes.
  */
-#define CRASH_COND(m_cond)                                                                                             \
-	if (unlikely(m_cond)) {                                                                                            \
+#define CRASH_COND(m_cond) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
-		::godot::_err_flush_stdout();                                                                                  \
-		GENERATE_TRAP();                                                                                               \
-	} else                                                                                                             \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -538,12 +538,12 @@ void _err_flush_stdout();
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the application crashes.
  */
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                                         \
-	if (unlikely(m_cond)) {                                                                                                   \
+#define CRASH_COND_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
-		::godot::_err_flush_stdout();                                                                                         \
-		GENERATE_TRAP();                                                                                                      \
-	} else                                                                                                                    \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 // Generic error macros.
@@ -555,11 +555,11 @@ void _err_flush_stdout();
  *
  * The current function returns.
  */
-#define ERR_FAIL()                                                                              \
-	if (true) {                                                                                 \
+#define ERR_FAIL() \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
-		return;                                                                                 \
-	} else                                                                                      \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -568,21 +568,21 @@ void _err_flush_stdout();
  *
  * Prints `m_msg`, and the current function returns.
  */
-#define ERR_FAIL_MSG(m_msg)                                                                            \
-	if (true) {                                                                                        \
+#define ERR_FAIL_MSG(m_msg) \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg); \
-		return;                                                                                        \
-	} else                                                                                             \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_EDMSG(m_msg)                                                                                \
-	if (true) {                                                                                              \
+#define ERR_FAIL_EDMSG(m_msg) \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg, true); \
-		return;                                                                                              \
-	} else                                                                                                   \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -592,11 +592,11 @@ void _err_flush_stdout();
  *
  * The current function returns `m_retval`.
  */
-#define ERR_FAIL_V(m_retval)                                                                                               \
-	if (true) {                                                                                                            \
+#define ERR_FAIL_V(m_retval) \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                                   \
-	} else                                                                                                                 \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -605,21 +605,21 @@ void _err_flush_stdout();
  *
  * Prints `m_msg`, and the current function returns `m_retval`.
  */
-#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                           \
-	if (true) {                                                                                                                   \
+#define ERR_FAIL_V_MSG(m_retval, m_msg) \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_V_EDMSG(m_retval, m_msg)                                                                                               \
-	if (true) {                                                                                                                         \
+#define ERR_FAIL_V_EDMSG(m_retval, m_msg) \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
-		return m_retval;                                                                                                                \
-	} else                                                                                                                              \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -641,27 +641,27 @@ void _err_flush_stdout();
 /**
  * Prints `m_msg` once during the application lifetime.
  */
-#define ERR_PRINT_ONCE(m_msg)                                                   \
-	if (true) {                                                                 \
-		static bool first_print = true;                                         \
-		if (first_print) {                                                      \
+#define ERR_PRINT_ONCE(m_msg) \
+	if (true) { \
+		static bool first_print = true; \
+		if (first_print) { \
 			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
-			first_print = false;                                                \
-		}                                                                       \
-	} else                                                                      \
+			first_print = false; \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_PRINT_ONCE` but also notifies the editor.
  */
-#define ERR_PRINT_ONCE_ED(m_msg)                                                      \
-	if (true) {                                                                       \
-		static bool first_print = true;                                               \
-		if (first_print) {                                                            \
+#define ERR_PRINT_ONCE_ED(m_msg) \
+	if (true) { \
+		static bool first_print = true; \
+		if (first_print) { \
 			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
-			first_print = false;                                                      \
-		}                                                                             \
-	} else                                                                            \
+			first_print = false; \
+		} \
+	} else \
 		((void)0)
 
 // Print warning message macros.
@@ -685,27 +685,27 @@ void _err_flush_stdout();
  *
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
-#define WARN_PRINT_ONCE(m_msg)                                                               \
-	if (true) {                                                                              \
-		static bool first_print = true;                                                      \
-		if (first_print) {                                                                   \
+#define WARN_PRINT_ONCE(m_msg) \
+	if (true) { \
+		static bool first_print = true; \
+		if (first_print) { \
 			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, true); \
-			first_print = false;                                                             \
-		}                                                                                    \
-	} else                                                                                   \
+			first_print = false; \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Same as `WARN_PRINT_ONCE` but also notifies the editor.
  */
-#define WARN_PRINT_ONCE_ED(m_msg)                                                           \
-	if (true) {                                                                             \
-		static bool first_print = true;                                                     \
-		if (first_print) {                                                                  \
+#define WARN_PRINT_ONCE_ED(m_msg) \
+	if (true) { \
+		static bool first_print = true; \
+		if (first_print) { \
 			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, true); \
-			first_print = false;                                                            \
-		}                                                                                   \
-	} else                                                                                  \
+			first_print = false; \
+		} \
+	} else \
 		((void)0)
 
 // Print deprecated warning message macros.
@@ -713,27 +713,27 @@ void _err_flush_stdout();
 /**
  * Warns that the current function is deprecated.
  */
-#define WARN_DEPRECATED                                                                                                                                     \
-	if (true) {                                                                                                                                             \
-		static std::atomic<bool> warning_shown;                                                                                                             \
-		if (!warning_shown.load()) {                                                                                                                        \
+#define WARN_DEPRECATED \
+	if (true) { \
+		static std::atomic<bool> warning_shown; \
+		if (!warning_shown.load()) { \
 			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, true); \
-			warning_shown.store(true);                                                                                                                      \
-		}                                                                                                                                                   \
-	} else                                                                                                                                                  \
+			warning_shown.store(true); \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Warns that the current function is deprecated and prints `m_msg`.
  */
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                 \
-	if (true) {                                                                                                                                                    \
-		static std::atomic<bool> warning_shown;                                                                                                                    \
-		if (!warning_shown.load()) {                                                                                                                               \
+#define WARN_DEPRECATED_MSG(m_msg) \
+	if (true) { \
+		static std::atomic<bool> warning_shown; \
+		if (!warning_shown.load()) { \
 			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, true); \
-			warning_shown.store(true);                                                                                                                             \
-		}                                                                                                                                                          \
-	} else                                                                                                                                                         \
+			warning_shown.store(true); \
+		} \
+	} else \
 		((void)0)
 
 /**
@@ -742,12 +742,12 @@ void _err_flush_stdout();
  *
  * The application crashes.
  */
-#define CRASH_NOW()                                                                                    \
-	if (true) {                                                                                        \
+#define CRASH_NOW() \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
-		::godot::_err_flush_stdout();                                                                  \
-		GENERATE_TRAP();                                                                               \
-	} else                                                                                             \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -755,12 +755,12 @@ void _err_flush_stdout();
  *
  * Prints `m_msg`, and then the application crashes.
  */
-#define CRASH_NOW_MSG(m_msg)                                                                                  \
-	if (true) {                                                                                               \
+#define CRASH_NOW_MSG(m_msg) \
+	if (true) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
-		::godot::_err_flush_stdout();                                                                         \
-		GENERATE_TRAP();                                                                                      \
-	} else                                                                                                    \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -768,12 +768,12 @@ void _err_flush_stdout();
  *  only used in dev builds.
  */
 #ifdef DEBUG_ENABLED
-#define DEV_ASSERT(m_cond)                                                                                                       \
-	if (unlikely(!(m_cond))) {                                                                                                   \
+#define DEV_ASSERT(m_cond) \
+	if (unlikely(!(m_cond))) { \
 		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-		::godot::_err_flush_stdout();                                                                                            \
-		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
+		::godot::_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 #else
 #define DEV_ASSERT(m_cond)
@@ -784,18 +784,18 @@ void _err_flush_stdout();
  * Avoids crashing the application in this case. It's not free, so it's debug only.
  */
 #ifdef DEBUG_ENABLED
-#define CHECK_METHOD_BIND_RET(m_mb, m_ret)                                                                         \
-	if (unlikely(!m_mb)) {                                                                                         \
+#define CHECK_METHOD_BIND_RET(m_mb, m_ret) \
+	if (unlikely(!m_mb)) { \
 		ERR_PRINT_ONCE("Method bind was not found. Likely the engine method changed to an incompatible version."); \
-		return m_ret;                                                                                              \
-	} else                                                                                                         \
+		return m_ret; \
+	} else \
 		((void)0)
 
-#define CHECK_METHOD_BIND(m_mb)                                                                                    \
-	if (unlikely(!m_mb)) {                                                                                         \
+#define CHECK_METHOD_BIND(m_mb) \
+	if (unlikely(!m_mb)) { \
 		ERR_PRINT_ONCE("Method bind was not found. Likely the engine method changed to an incompatible version."); \
-		return;                                                                                                    \
-	} else                                                                                                         \
+		return; \
+	} else \
 		((void)0)
 #else
 #define CHECK_METHOD_BIND_RET(m_mb, m_ret)

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -41,76 +41,76 @@ namespace godot {
 template <typename T>
 struct PtrToArg {};
 
-#define MAKE_PTRARG(m_type)                                            \
-	template <>                                                        \
-	struct PtrToArg<m_type> {                                          \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);           \
-		}                                                              \
-		typedef m_type EncodeT;                                        \
+#define MAKE_PTRARG(m_type) \
+	template <> \
+	struct PtrToArg<m_type> { \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) { \
+			return *reinterpret_cast<const m_type *>(p_ptr); \
+		} \
+		typedef m_type EncodeT; \
 		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
-			*reinterpret_cast<m_type *>(p_ptr) = p_val;                \
-		}                                                              \
-	};                                                                 \
-	template <>                                                        \
-	struct PtrToArg<const m_type &> {                                  \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);           \
-		}                                                              \
-		typedef m_type EncodeT;                                        \
+			*reinterpret_cast<m_type *>(p_ptr) = p_val; \
+		} \
+	}; \
+	template <> \
+	struct PtrToArg<const m_type &> { \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) { \
+			return *reinterpret_cast<const m_type *>(p_ptr); \
+		} \
+		typedef m_type EncodeT; \
 		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
-			*reinterpret_cast<m_type *>(p_ptr) = p_val;                \
-		}                                                              \
+			*reinterpret_cast<m_type *>(p_ptr) = p_val; \
+		} \
 	}
 
-#define MAKE_PTRARGCONV(m_type, m_conv)                                           \
-	template <>                                                                   \
-	struct PtrToArg<m_type> {                                                     \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
+#define MAKE_PTRARGCONV(m_type, m_conv) \
+	template <> \
+	struct PtrToArg<m_type> { \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) { \
 			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
-		}                                                                         \
-		typedef m_conv EncodeT;                                                   \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
-			*reinterpret_cast<m_conv *>(p_ptr) = static_cast<m_conv>(p_val);      \
-		}                                                                         \
-		_FORCE_INLINE_ static m_conv encode_arg(m_type p_val) {                   \
-			return static_cast<m_conv>(p_val);                                    \
-		}                                                                         \
-	};                                                                            \
-	template <>                                                                   \
-	struct PtrToArg<const m_type &> {                                             \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
+		} \
+		typedef m_conv EncodeT; \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
+			*reinterpret_cast<m_conv *>(p_ptr) = static_cast<m_conv>(p_val); \
+		} \
+		_FORCE_INLINE_ static m_conv encode_arg(m_type p_val) { \
+			return static_cast<m_conv>(p_val); \
+		} \
+	}; \
+	template <> \
+	struct PtrToArg<const m_type &> { \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) { \
 			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
-		}                                                                         \
-		typedef m_conv EncodeT;                                                   \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
-			*reinterpret_cast<m_conv *>(p_ptr) = static_cast<m_conv>(p_val);      \
-		}                                                                         \
-		_FORCE_INLINE_ static m_conv encode_arg(m_type p_val) {                   \
-			return static_cast<m_conv>(p_val);                                    \
-		}                                                                         \
+		} \
+		typedef m_conv EncodeT; \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
+			*reinterpret_cast<m_conv *>(p_ptr) = static_cast<m_conv>(p_val); \
+		} \
+		_FORCE_INLINE_ static m_conv encode_arg(m_type p_val) { \
+			return static_cast<m_conv>(p_val); \
+		} \
 	}
 
-#define MAKE_PTRARG_BY_REFERENCE(m_type)                                      \
-	template <>                                                               \
-	struct PtrToArg<m_type> {                                                 \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
-			return *reinterpret_cast<const m_type *>(p_ptr);                  \
-		}                                                                     \
-		typedef m_type EncodeT;                                               \
+#define MAKE_PTRARG_BY_REFERENCE(m_type) \
+	template <> \
+	struct PtrToArg<m_type> { \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) { \
+			return *reinterpret_cast<const m_type *>(p_ptr); \
+		} \
+		typedef m_type EncodeT; \
 		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
-			*reinterpret_cast<m_type *>(p_ptr) = p_val;                       \
-		}                                                                     \
-	};                                                                        \
-	template <>                                                               \
-	struct PtrToArg<const m_type &> {                                         \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
-			return *reinterpret_cast<const m_type *>(p_ptr);                  \
-		}                                                                     \
-		typedef m_type EncodeT;                                               \
+			*reinterpret_cast<m_type *>(p_ptr) = p_val; \
+		} \
+	}; \
+	template <> \
+	struct PtrToArg<const m_type &> { \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) { \
+			return *reinterpret_cast<const m_type *>(p_ptr); \
+		} \
+		typedef m_type EncodeT; \
 		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
-			*reinterpret_cast<m_type *>(p_ptr) = p_val;                       \
-		}                                                                     \
+			*reinterpret_cast<m_type *>(p_ptr) = p_val; \
+		} \
 	}
 
 MAKE_PTRARGCONV(bool, uint8_t);
@@ -194,27 +194,27 @@ struct PtrToArg<const T *> {
 };
 
 // Pointers.
-#define GDVIRTUAL_NATIVE_PTR(m_type)                                          \
-	template <>                                                               \
-	struct PtrToArg<m_type *> {                                               \
-		_FORCE_INLINE_ static m_type *convert(const void *p_ptr) {            \
-			return (m_type *)(*(void **)p_ptr);                               \
-		}                                                                     \
-		typedef m_type *EncodeT;                                              \
-		_FORCE_INLINE_ static void encode(m_type *p_var, void *p_ptr) {       \
-			*reinterpret_cast<m_type **>(p_ptr) = p_var;                      \
-		}                                                                     \
-	};                                                                        \
-                                                                              \
-	template <>                                                               \
-	struct PtrToArg<const m_type *> {                                         \
-		_FORCE_INLINE_ static const m_type *convert(const void *p_ptr) {      \
-			return (const m_type *)(*(const void **)p_ptr);                   \
-		}                                                                     \
-		typedef const m_type *EncodeT;                                        \
+#define GDVIRTUAL_NATIVE_PTR(m_type) \
+	template <> \
+	struct PtrToArg<m_type *> { \
+		_FORCE_INLINE_ static m_type *convert(const void *p_ptr) { \
+			return (m_type *)(*(void **)p_ptr); \
+		} \
+		typedef m_type *EncodeT; \
+		_FORCE_INLINE_ static void encode(m_type *p_var, void *p_ptr) { \
+			*reinterpret_cast<m_type **>(p_ptr) = p_var; \
+		} \
+	}; \
+\
+	template <> \
+	struct PtrToArg<const m_type *> { \
+		_FORCE_INLINE_ static const m_type *convert(const void *p_ptr) { \
+			return (const m_type *)(*(const void **)p_ptr); \
+		} \
+		typedef const m_type *EncodeT; \
 		_FORCE_INLINE_ static void encode(const m_type *p_var, void *p_ptr) { \
-			*reinterpret_cast<const m_type **>(p_ptr) = p_var;                \
-		}                                                                     \
+			*reinterpret_cast<const m_type **>(p_ptr) = p_var; \
+		} \
 	}
 
 GDVIRTUAL_NATIVE_PTR(void);

--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -103,40 +103,40 @@ static PropertyInfo make_property_info(Variant::Type p_type, const StringName &p
 template <typename T, typename = void>
 struct GetTypeInfo;
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                                                                            \
-	template <>                                                                                                       \
-	struct GetTypeInfo<m_type> {                                                                                      \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type;                                            \
+#define MAKE_TYPE_INFO(m_type, m_var_type) \
+	template <> \
+	struct GetTypeInfo<m_type> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type; \
 		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                                                 \
-			return make_property_info((Variant::Type)VARIANT_TYPE, "");                                               \
-		}                                                                                                             \
-	};                                                                                                                \
-	template <>                                                                                                       \
-	struct GetTypeInfo<const m_type &> {                                                                              \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type;                                            \
+		static inline PropertyInfo get_class_info() { \
+			return make_property_info((Variant::Type)VARIANT_TYPE, ""); \
+		} \
+	}; \
+	template <> \
+	struct GetTypeInfo<const m_type &> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type; \
 		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                                                 \
-			return make_property_info((Variant::Type)VARIANT_TYPE, "");                                               \
-		}                                                                                                             \
+		static inline PropertyInfo get_class_info() { \
+			return make_property_info((Variant::Type)VARIANT_TYPE, ""); \
+		} \
 	};
 
-#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)                       \
-	template <>                                                                        \
-	struct GetTypeInfo<m_type> {                                                       \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type;             \
+#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata) \
+	template <> \
+	struct GetTypeInfo<m_type> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type; \
 		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {                                  \
-			return make_property_info((Variant::Type)VARIANT_TYPE, "");                \
-		}                                                                              \
-	};                                                                                 \
-	template <>                                                                        \
-	struct GetTypeInfo<const m_type &> {                                               \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type;             \
+		static inline PropertyInfo get_class_info() { \
+			return make_property_info((Variant::Type)VARIANT_TYPE, ""); \
+		} \
+	}; \
+	template <> \
+	struct GetTypeInfo<const m_type &> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = m_var_type; \
 		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {                                  \
-			return make_property_info((Variant::Type)VARIANT_TYPE, "");                \
-		}                                                                              \
+		static inline PropertyInfo get_class_info() { \
+			return make_property_info((Variant::Type)VARIANT_TYPE, ""); \
+		} \
 	};
 
 MAKE_TYPE_INFO(bool, GDEXTENSION_VARIANT_TYPE_BOOL)
@@ -234,21 +234,21 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 	return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
 }
 
-#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                            \
-	template <>                                                                                                                              \
-	struct GetTypeInfo<m_impl> {                                                                                                             \
-		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                          \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                        \
-		static inline PropertyInfo get_class_info() {                                                                                        \
+#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl) \
+	template <> \
+	struct GetTypeInfo<m_impl> { \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return make_property_info(Variant::Type::INT, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
-					enum_qualified_name_to_class_info_name(#m_enum));                                                                        \
-		}                                                                                                                                    \
+					enum_qualified_name_to_class_info_name(#m_enum)); \
+		} \
 	};
 
-#define MAKE_ENUM_TYPE_INFO(m_enum)                 \
-	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum)       \
+#define MAKE_ENUM_TYPE_INFO(m_enum) \
+	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum) \
 	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum const) \
-	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum &)     \
+	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum &) \
 	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, const m_enum &)
 
 template <typename T>
@@ -272,30 +272,30 @@ public:
 	_FORCE_INLINE_ operator Variant() const { return value; }
 };
 
-#define TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_impl)                                                                                            \
-	template <>                                                                                                                                  \
-	struct GetTypeInfo<m_impl> {                                                                                                                 \
-		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                            \
-		static inline PropertyInfo get_class_info() {                                                                                            \
+#define TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_impl) \
+	template <> \
+	struct GetTypeInfo<m_impl> { \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return make_property_info(Variant::Type::INT, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
-					enum_qualified_name_to_class_info_name(#m_enum));                                                                            \
-		}                                                                                                                                        \
-	};                                                                                                                                           \
-	template <>                                                                                                                                  \
-	struct GetTypeInfo<BitField<m_impl>> {                                                                                                       \
-		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                            \
-		static inline PropertyInfo get_class_info() {                                                                                            \
+					enum_qualified_name_to_class_info_name(#m_enum)); \
+		} \
+	}; \
+	template <> \
+	struct GetTypeInfo<BitField<m_impl>> { \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return make_property_info(Variant::Type::INT, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
-					enum_qualified_name_to_class_info_name(#m_enum));                                                                            \
-		}                                                                                                                                        \
+					enum_qualified_name_to_class_info_name(#m_enum)); \
+		} \
 	};
 
-#define MAKE_BITFIELD_TYPE_INFO(m_enum)                 \
-	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum)       \
+#define MAKE_BITFIELD_TYPE_INFO(m_enum) \
+	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum) \
 	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum const) \
-	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum &)     \
+	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum &) \
 	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, const m_enum &)
 
 template <typename T>
@@ -344,22 +344,22 @@ struct GetTypeInfo<const TypedArray<T> &> {
 	}
 };
 
-#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type)                                                                                                \
-	template <>                                                                                                                                      \
-	struct GetTypeInfo<TypedArray<m_type>> {                                                                                                         \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_ARRAY;                                                       \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                \
-		static inline PropertyInfo get_class_info() {                                                                                                \
+#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type) \
+	template <> \
+	struct GetTypeInfo<TypedArray<m_type>> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_ARRAY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return make_property_info(Variant::Type::ARRAY, "", PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type).utf8().get_data()); \
-		}                                                                                                                                            \
-	};                                                                                                                                               \
-	template <>                                                                                                                                      \
-	struct GetTypeInfo<const TypedArray<m_type> &> {                                                                                                 \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_ARRAY;                                                       \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                \
-		static inline PropertyInfo get_class_info() {                                                                                                \
+		} \
+	}; \
+	template <> \
+	struct GetTypeInfo<const TypedArray<m_type> &> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_ARRAY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return make_property_info(Variant::Type::ARRAY, "", PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type).utf8().get_data()); \
-		}                                                                                                                                            \
+		} \
 	};
 
 MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)

--- a/include/godot_cpp/templates/safe_refcount.hpp
+++ b/include/godot_cpp/templates/safe_refcount.hpp
@@ -48,11 +48,11 @@ namespace godot {
 //   even with threads that are already running.
 
 // These are used in very specific areas of the engine where it's critical that these guarantees are held
-#define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type)                             \
-	static_assert(sizeof(::godot::SafeNumeric<m_type>) == sizeof(m_type));   \
+#define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type) \
+	static_assert(sizeof(::godot::SafeNumeric<m_type>) == sizeof(m_type)); \
 	static_assert(alignof(::godot::SafeNumeric<m_type>) == alignof(m_type)); \
 	static_assert(std::is_trivially_destructible_v<std::atomic<m_type>>);
-#define SAFE_FLAG_TYPE_PUN_GUARANTEES                         \
+#define SAFE_FLAG_TYPE_PUN_GUARANTEES \
 	static_assert(sizeof(::godot::SafeFlag) == sizeof(bool)); \
 	static_assert(alignof(::godot::SafeFlag) == alignof(bool));
 

--- a/include/godot_cpp/templates/sort_array.hpp
+++ b/include/godot_cpp/templates/sort_array.hpp
@@ -34,10 +34,10 @@
 
 namespace godot {
 
-#define ERR_BAD_COMPARE(cond)                                         \
-	if (unlikely(cond)) {                                             \
+#define ERR_BAD_COMPARE(cond) \
+	if (unlikely(cond)) { \
 		ERR_PRINT("bad comparison function; sorting will be broken"); \
-		break;                                                        \
+		break; \
 	}
 
 template <typename T>

--- a/include/godot_cpp/variant/char_utils.hpp
+++ b/include/godot_cpp/variant/char_utils.hpp
@@ -34,23 +34,23 @@
 
 namespace godot {
 
-#define BSEARCH_CHAR_RANGE(m_array)                      \
-	int low = 0;                                         \
+#define BSEARCH_CHAR_RANGE(m_array) \
+	int low = 0; \
 	int high = sizeof(m_array) / sizeof(m_array[0]) - 1; \
-	int middle = (low + high) / 2;                       \
-                                                         \
-	while (low <= high) {                                \
-		if (p_char < m_array[middle].start) {            \
-			high = middle - 1;                           \
-		} else if (p_char > m_array[middle].end) {       \
-			low = middle + 1;                            \
-		} else {                                         \
-			return true;                                 \
-		}                                                \
-                                                         \
-		middle = (low + high) / 2;                       \
-	}                                                    \
-                                                         \
+	int middle = (low + high) / 2; \
+\
+	while (low <= high) { \
+		if (p_char < m_array[middle].start) { \
+			high = middle - 1; \
+		} else if (p_char > m_array[middle].end) { \
+			low = middle + 1; \
+		} else { \
+			return true; \
+		} \
+\
+		middle = (low + high) / 2; \
+	} \
+\
 	return false
 
 constexpr bool is_unicode_identifier_start(char32_t p_char) {

--- a/include/godot_cpp/variant/typed_array.hpp
+++ b/include/godot_cpp/variant/typed_array.hpp
@@ -62,31 +62,31 @@ public:
 
 // specialization for the rest of variant types
 
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
-	template <>                                                                                                  \
-	class TypedArray<m_type> : public Array {                                                                    \
-	public:                                                                                                      \
-		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
+#define MAKE_TYPED_ARRAY(m_type, m_variant_type) \
+	template <> \
+	class TypedArray<m_type> : public Array { \
+	public: \
+		_FORCE_INLINE_ void operator=(const Array &p_array) { \
 			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
-			Array::operator=(p_array);                                                                           \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :                                       \
-				Array(Array(p_init), m_variant_type, StringName(), Variant()) {                                  \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
-				TypedArray(Array(p_variant)) {                                                                   \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Array &p_array) {                                                        \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-			if (is_same_typed(p_array)) {                                                                        \
-				Array::operator=(p_array);                                                                       \
-			} else {                                                                                             \
-				assign(p_array);                                                                                 \
-			}                                                                                                    \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-		}                                                                                                        \
+			Array::operator=(p_array); \
+		} \
+		_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) : \
+				Array(Array(p_init), m_variant_type, StringName(), Variant()) { \
+		} \
+		_FORCE_INLINE_ TypedArray(const Variant &p_variant) : \
+				TypedArray(Array(p_variant)) { \
+		} \
+		_FORCE_INLINE_ TypedArray(const Array &p_array) { \
+			set_typed(m_variant_type, StringName(), Variant()); \
+			if (is_same_typed(p_array)) { \
+				Array::operator=(p_array); \
+			} else { \
+				assign(p_array); \
+			} \
+		} \
+		_FORCE_INLINE_ TypedArray() { \
+			set_typed(m_variant_type, StringName(), Variant()); \
+		} \
 	};
 
 // All Variant::OBJECT types are intentionally omitted from this list because they are handled by

--- a/include/godot_cpp/variant/typed_dictionary.hpp
+++ b/include/godot_cpp/variant/typed_dictionary.hpp
@@ -73,144 +73,144 @@ public:
 
 //specialization for the rest of variant types
 
-#define MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type)                                                                             \
-	template <typename T>                                                                                                                     \
-	class TypedDictionary<T, m_type> : public Dictionary {                                                                                    \
-	public:                                                                                                                                   \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                                       \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                    \
-			Dictionary::operator=(p_dictionary);                                                                                              \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                            \
-				TypedDictionary(Dictionary(p_variant)) {                                                                                      \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                      \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                            \
-			if (is_same_typed(p_dictionary)) {                                                                                                \
-				Dictionary::operator=(p_dictionary);                                                                                          \
-			} else {                                                                                                                          \
-				assign(p_dictionary);                                                                                                         \
-			}                                                                                                                                 \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                                    \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                            \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<T, m_type>> p_init) :                                                   \
-				Dictionary() {                                                                                                                \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                            \
-			for (const KeyValue<T, m_type> &E : p_init) {                                                                                     \
-				operator[](E.key) = E.value;                                                                                                  \
-			}                                                                                                                                 \
-		}                                                                                                                                     \
-	};                                                                                                                                        \
-	template <typename T>                                                                                                                     \
-	class TypedDictionary<m_type, T> : public Dictionary {                                                                                    \
-	public:                                                                                                                                   \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                                       \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                    \
-			Dictionary::operator=(p_dictionary);                                                                                              \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                            \
-				TypedDictionary(Dictionary(p_variant)) {                                                                                      \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                      \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                            \
-			if (is_same_typed(p_dictionary)) {                                                                                                \
-				Dictionary::operator=(p_dictionary);                                                                                          \
-			} else {                                                                                                                          \
-				assign(p_dictionary);                                                                                                         \
-			}                                                                                                                                 \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                                    \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                            \
-		}                                                                                                                                     \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type, T>> p_init) :                                                   \
-				Dictionary() {                                                                                                                \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, std::remove_pointer<T>::type::get_class_static(), Variant()); \
-			for (const KeyValue<m_type, T> &E : p_init) {                                                                                     \
-				operator[](E.key) = E.value;                                                                                                  \
-			}                                                                                                                                 \
-		}                                                                                                                                     \
-	};
-
-#define MAKE_TYPED_DICTIONARY_EXPANDED(m_type_key, m_variant_type_key, m_type_value, m_variant_type_value)                 \
-	template <>                                                                                                            \
-	class TypedDictionary<m_type_key, m_type_value> : public Dictionary {                                                  \
-	public:                                                                                                                \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                    \
+#define MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type) \
+	template <typename T> \
+	class TypedDictionary<T, m_type> : public Dictionary { \
+	public: \
+		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) { \
 			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type."); \
-			Dictionary::operator=(p_dictionary);                                                                           \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                         \
-				TypedDictionary(Dictionary(p_variant)) {                                                                   \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                   \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());         \
-			if (is_same_typed(p_dictionary)) {                                                                             \
-				Dictionary::operator=(p_dictionary);                                                                       \
-			} else {                                                                                                       \
-				assign(p_dictionary);                                                                                      \
-			}                                                                                                              \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                 \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());         \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type_key, m_type_value>> p_init) :                 \
-				Dictionary() {                                                                                             \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());         \
-			for (const KeyValue<m_type_key, m_type_value> &E : p_init) {                                                   \
-				operator[](E.key) = E.value;                                                                               \
-			}                                                                                                              \
-		}                                                                                                                  \
+			Dictionary::operator=(p_dictionary); \
+		} \
+		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) : \
+				TypedDictionary(Dictionary(p_variant)) { \
+		} \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) { \
+			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant()); \
+			if (is_same_typed(p_dictionary)) { \
+				Dictionary::operator=(p_dictionary); \
+			} else { \
+				assign(p_dictionary); \
+			} \
+		} \
+		_FORCE_INLINE_ TypedDictionary() { \
+			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant()); \
+		} \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<T, m_type>> p_init) : \
+				Dictionary() { \
+			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant()); \
+			for (const KeyValue<T, m_type> &E : p_init) { \
+				operator[](E.key) = E.value; \
+			} \
+		} \
+	}; \
+	template <typename T> \
+	class TypedDictionary<m_type, T> : public Dictionary { \
+	public: \
+		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) { \
+			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type."); \
+			Dictionary::operator=(p_dictionary); \
+		} \
+		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) : \
+				TypedDictionary(Dictionary(p_variant)) { \
+		} \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) { \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant()); \
+			if (is_same_typed(p_dictionary)) { \
+				Dictionary::operator=(p_dictionary); \
+			} else { \
+				assign(p_dictionary); \
+			} \
+		} \
+		_FORCE_INLINE_ TypedDictionary() { \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant()); \
+		} \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type, T>> p_init) : \
+				Dictionary() { \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, std::remove_pointer<T>::type::get_class_static(), Variant()); \
+			for (const KeyValue<m_type, T> &E : p_init) { \
+				operator[](E.key) = E.value; \
+			} \
+		} \
 	};
 
-#define MAKE_TYPED_DICTIONARY_NIL(m_type, m_variant_type)                                                     \
-	MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type)                                                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, bool, Variant::BOOL)                               \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint8_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int8_t, Variant::INT)                              \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint16_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int16_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint32_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int32_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint64_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int64_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, float, Variant::FLOAT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, double, Variant::FLOAT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, String, Variant::STRING)                           \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector2, Variant::VECTOR2)                         \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector2i, Variant::VECTOR2I)                       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Rect2, Variant::RECT2)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Rect2i, Variant::RECT2I)                           \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector3, Variant::VECTOR3)                         \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector3i, Variant::VECTOR3I)                       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Transform2D, Variant::TRANSFORM2D)                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Plane, Variant::PLANE)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Quaternion, Variant::QUATERNION)                   \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, AABB, Variant::AABB)                               \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Basis, Variant::BASIS)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Transform3D, Variant::TRANSFORM3D)                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Color, Variant::COLOR)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, StringName, Variant::STRING_NAME)                  \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, NodePath, Variant::NODE_PATH)                      \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, RID, Variant::RID)                                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Callable, Variant::CALLABLE)                       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Signal, Variant::SIGNAL)                           \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Dictionary, Variant::DICTIONARY)                   \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Array, Variant::ARRAY)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedByteArray, Variant::PACKED_BYTE_ARRAY)       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedInt32Array, Variant::PACKED_INT32_ARRAY)     \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedInt64Array, Variant::PACKED_INT64_ARRAY)     \
+#define MAKE_TYPED_DICTIONARY_EXPANDED(m_type_key, m_variant_type_key, m_type_value, m_variant_type_value) \
+	template <> \
+	class TypedDictionary<m_type_key, m_type_value> : public Dictionary { \
+	public: \
+		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) { \
+			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type."); \
+			Dictionary::operator=(p_dictionary); \
+		} \
+		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) : \
+				TypedDictionary(Dictionary(p_variant)) { \
+		} \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) { \
+			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant()); \
+			if (is_same_typed(p_dictionary)) { \
+				Dictionary::operator=(p_dictionary); \
+			} else { \
+				assign(p_dictionary); \
+			} \
+		} \
+		_FORCE_INLINE_ TypedDictionary() { \
+			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant()); \
+		} \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type_key, m_type_value>> p_init) : \
+				Dictionary() { \
+			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant()); \
+			for (const KeyValue<m_type_key, m_type_value> &E : p_init) { \
+				operator[](E.key) = E.value; \
+			} \
+		} \
+	};
+
+#define MAKE_TYPED_DICTIONARY_NIL(m_type, m_variant_type) \
+	MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, bool, Variant::BOOL) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint8_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int8_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint16_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int16_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint32_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int32_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint64_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int64_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, float, Variant::FLOAT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, double, Variant::FLOAT) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, String, Variant::STRING) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector2, Variant::VECTOR2) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector2i, Variant::VECTOR2I) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Rect2, Variant::RECT2) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Rect2i, Variant::RECT2I) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector3, Variant::VECTOR3) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector3i, Variant::VECTOR3I) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Transform2D, Variant::TRANSFORM2D) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Plane, Variant::PLANE) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Quaternion, Variant::QUATERNION) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, AABB, Variant::AABB) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Basis, Variant::BASIS) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Transform3D, Variant::TRANSFORM3D) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Color, Variant::COLOR) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, StringName, Variant::STRING_NAME) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, NodePath, Variant::NODE_PATH) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, RID, Variant::RID) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Callable, Variant::CALLABLE) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Signal, Variant::SIGNAL) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Dictionary, Variant::DICTIONARY) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Array, Variant::ARRAY) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedByteArray, Variant::PACKED_BYTE_ARRAY) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedInt32Array, Variant::PACKED_INT32_ARRAY) \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedInt64Array, Variant::PACKED_INT64_ARRAY) \
 	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY) \
 	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedStringArray, Variant::PACKED_STRING_ARRAY)   \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedStringArray, Variant::PACKED_STRING_ARRAY) \
 	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY) \
 	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedColorArray, Variant::PACKED_COLOR_ARRAY)     \
+	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedColorArray, Variant::PACKED_COLOR_ARRAY) \
 	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY) \
 	/*MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, IPAddress, Variant::STRING)*/
 
-#define MAKE_TYPED_DICTIONARY(m_type, m_variant_type)                             \
+#define MAKE_TYPED_DICTIONARY(m_type, m_variant_type) \
 	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Variant, Variant::NIL) \
 	MAKE_TYPED_DICTIONARY_NIL(m_type, m_variant_type)
 
@@ -304,113 +304,113 @@ struct GetTypeInfo<const TypedDictionary<K, V> &> {
 	}
 };
 
-#define MAKE_TYPED_DICTIONARY_INFO_WITH_OBJECT(m_type, m_variant_type)                                                                                                     \
-	template <typename T>                                                                                                                                                  \
-	struct GetTypeInfo<TypedDictionary<T, m_type>> {                                                                                                                       \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY;                                                                        \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                                      \
-		static inline PropertyInfo get_class_info() {                                                                                                                      \
-			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                                        \
+#define MAKE_TYPED_DICTIONARY_INFO_WITH_OBJECT(m_type, m_variant_type) \
+	template <typename T> \
+	struct GetTypeInfo<TypedDictionary<T, m_type>> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, \
 					vformat("%s;%s", T::get_class_static(), m_variant_type == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type).utf8().get_data())); \
-		}                                                                                                                                                                  \
-	};                                                                                                                                                                     \
-	template <typename T>                                                                                                                                                  \
-	struct GetTypeInfo<const TypedDictionary<T, m_type> &> {                                                                                                               \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY;                                                                        \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                                      \
-		static inline PropertyInfo get_class_info() {                                                                                                                      \
-			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                                        \
+		} \
+	}; \
+	template <typename T> \
+	struct GetTypeInfo<const TypedDictionary<T, m_type> &> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, \
 					vformat("%s;%s", T::get_class_static(), m_variant_type == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type).utf8().get_data())); \
-		}                                                                                                                                                                  \
-	};                                                                                                                                                                     \
-	template <typename T>                                                                                                                                                  \
-	struct GetTypeInfo<TypedDictionary<m_type, T>> {                                                                                                                       \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY;                                                                        \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                                      \
-		static inline PropertyInfo get_class_info() {                                                                                                                      \
-			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                                        \
+		} \
+	}; \
+	template <typename T> \
+	struct GetTypeInfo<TypedDictionary<m_type, T>> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, \
 					vformat("%s;%s", m_variant_type == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type).utf8().get_data(), T::get_class_static())); \
-		}                                                                                                                                                                  \
-	};                                                                                                                                                                     \
-	template <typename T>                                                                                                                                                  \
-	struct GetTypeInfo<const TypedDictionary<m_type, T> &> {                                                                                                               \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY;                                                                        \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                                      \
-		static inline PropertyInfo get_class_info() {                                                                                                                      \
-			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                                        \
+		} \
+	}; \
+	template <typename T> \
+	struct GetTypeInfo<const TypedDictionary<m_type, T> &> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, \
 					vformat("%s;%s", m_variant_type == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type).utf8().get_data(), T::get_class_static())); \
-		}                                                                                                                                                                  \
+		} \
 	};
 
-#define MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type_key, m_variant_type_key, m_type_value, m_variant_type_value)                                           \
-	template <>                                                                                                                                           \
-	struct GetTypeInfo<TypedDictionary<m_type_key, m_type_value>> {                                                                                       \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY;                                                       \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                     \
-		static inline PropertyInfo get_class_info() {                                                                                                     \
-			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                       \
+#define MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type_key, m_variant_type_key, m_type_value, m_variant_type_value) \
+	template <> \
+	struct GetTypeInfo<TypedDictionary<m_type_key, m_type_value>> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, \
 					vformat("%s;%s", m_variant_type_key == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type_key).utf8().get_data(), \
-							m_variant_type_value == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type_value).utf8().get_data()));    \
-		}                                                                                                                                                 \
-	};                                                                                                                                                    \
-	template <>                                                                                                                                           \
-	struct GetTypeInfo<const TypedDictionary<m_type_key, m_type_value> &> {                                                                               \
-		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY;                                                       \
-		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;                                     \
-		static inline PropertyInfo get_class_info() {                                                                                                     \
-			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                       \
+							m_variant_type_value == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type_value).utf8().get_data())); \
+		} \
+	}; \
+	template <> \
+	struct GetTypeInfo<const TypedDictionary<m_type_key, m_type_value> &> { \
+		static constexpr GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_DICTIONARY; \
+		static constexpr GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(Variant::Type::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, \
 					vformat("%s;%s", m_variant_type_key == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type_key).utf8().get_data(), \
-							m_variant_type_value == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type_value).utf8().get_data()));    \
-		}                                                                                                                                                 \
+							m_variant_type_value == Variant::Type::NIL ? "Variant" : Variant::get_type_name(m_variant_type_value).utf8().get_data())); \
+		} \
 	};
 
-#define MAKE_TYPED_DICTIONARY_INFO_NIL(m_type, m_variant_type)                                                     \
-	MAKE_TYPED_DICTIONARY_INFO_WITH_OBJECT(m_type, m_variant_type)                                                 \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, bool, Variant::BOOL)                               \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint8_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int8_t, Variant::INT)                              \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint16_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int16_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint32_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int32_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint64_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int64_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, float, Variant::FLOAT)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, double, Variant::FLOAT)                            \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, String, Variant::STRING)                           \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector2, Variant::VECTOR2)                         \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector2i, Variant::VECTOR2I)                       \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Rect2, Variant::RECT2)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Rect2i, Variant::RECT2I)                           \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector3, Variant::VECTOR3)                         \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector3i, Variant::VECTOR3I)                       \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Transform2D, Variant::TRANSFORM2D)                 \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Plane, Variant::PLANE)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Quaternion, Variant::QUATERNION)                   \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, AABB, Variant::AABB)                               \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Basis, Variant::BASIS)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Transform3D, Variant::TRANSFORM3D)                 \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Color, Variant::COLOR)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, StringName, Variant::STRING_NAME)                  \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, NodePath, Variant::NODE_PATH)                      \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, RID, Variant::RID)                                 \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Callable, Variant::CALLABLE)                       \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Signal, Variant::SIGNAL)                           \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Dictionary, Variant::DICTIONARY)                   \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Array, Variant::ARRAY)                             \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedByteArray, Variant::PACKED_BYTE_ARRAY)       \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedInt32Array, Variant::PACKED_INT32_ARRAY)     \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedInt64Array, Variant::PACKED_INT64_ARRAY)     \
+#define MAKE_TYPED_DICTIONARY_INFO_NIL(m_type, m_variant_type) \
+	MAKE_TYPED_DICTIONARY_INFO_WITH_OBJECT(m_type, m_variant_type) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, bool, Variant::BOOL) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint8_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int8_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint16_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int16_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint32_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int32_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, uint64_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, int64_t, Variant::INT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, float, Variant::FLOAT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, double, Variant::FLOAT) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, String, Variant::STRING) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector2, Variant::VECTOR2) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector2i, Variant::VECTOR2I) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Rect2, Variant::RECT2) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Rect2i, Variant::RECT2I) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector3, Variant::VECTOR3) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Vector3i, Variant::VECTOR3I) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Transform2D, Variant::TRANSFORM2D) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Plane, Variant::PLANE) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Quaternion, Variant::QUATERNION) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, AABB, Variant::AABB) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Basis, Variant::BASIS) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Transform3D, Variant::TRANSFORM3D) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Color, Variant::COLOR) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, StringName, Variant::STRING_NAME) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, NodePath, Variant::NODE_PATH) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, RID, Variant::RID) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Callable, Variant::CALLABLE) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Signal, Variant::SIGNAL) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Dictionary, Variant::DICTIONARY) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Array, Variant::ARRAY) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedByteArray, Variant::PACKED_BYTE_ARRAY) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedInt32Array, Variant::PACKED_INT32_ARRAY) \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedInt64Array, Variant::PACKED_INT64_ARRAY) \
 	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY) \
 	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY) \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedStringArray, Variant::PACKED_STRING_ARRAY)   \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedStringArray, Variant::PACKED_STRING_ARRAY) \
 	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY) \
 	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY) \
 	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY) \
-	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedColorArray, Variant::PACKED_COLOR_ARRAY)     \
+	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, PackedColorArray, Variant::PACKED_COLOR_ARRAY) \
 	/* MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, IPAddress, Variant::STRING) */
 
-#define MAKE_TYPED_DICTIONARY_INFO(m_type, m_variant_type)                             \
+#define MAKE_TYPED_DICTIONARY_INFO(m_type, m_variant_type) \
 	MAKE_TYPED_DICTIONARY_INFO_EXPANDED(m_type, m_variant_type, Variant, Variant::NIL) \
 	MAKE_TYPED_DICTIONARY_INFO_NIL(m_type, m_variant_type)
 


### PR DESCRIPTION
Matches upstream via https://github.com/godotengine/godot/pull/112381.
