### PR TITLE
PropertyInfo: Only include 'usage' in Dictionary conversion when explicitly set

### DIFF
--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -78,7 +78,9 @@ struct PropertyInfo {
 		dict["type"] = type;
 		dict["hint"] = hint;
 		dict["hint_string"] = hint_string;
-		dict["usage"] = usage;
+		if (usage != PROPERTY_USAGE_NONE) {
+			dict["usage"] = usage;
+		}
 		return dict;
 	}
 


### PR DESCRIPTION
The implicit conversion from `PropertyInfo` to `Dictionary` currently includes the `usage` field unconditionally.

In recent Godot versions, support for the `usage` field has been removed from `add_property_info()` for both `EditorSettings` and `ProjectSettings` triggering the following warning whenever `PropertyInfo` is used:

```
WARNING: "usage" is not supported in add_property_info().
```
This causes unnecessary warning spam in the editor console when registering custom settings from GDExtension using `PropertyInfo`.

Fix is quite simple, We add a check in `PropertyInfo::operator Dictionary()` that assigns the `usage` field only when it's set to a value other than `PROPERTY_USAGE_NONE`.

```CPP
operator Dictionary() const {
	Dictionary dict;
	dict["name"] = name;
	dict["class_name"] = class_name;
	dict["type"] = type;
	dict["hint"] = hint;
	dict["hint_string"] = hint_string;
	if (usage != PROPERTY_USAGE_NONE) {
		dict["usage"] = usage;
	}
	return dict;
}
```