### PR TITLE
Add `SceneTree::get_singleton()`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1953,6 +1953,9 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
             "\tGroupID add_native_group_task(void (*p_func)(void *, uint32_t), void *p_userdata, int p_elements, int p_tasks = -1, bool p_high_priority = false, const String &p_description = String());"
         )
 
+    if class_name == "SceneTree":
+        result.append("\tstatic SceneTree *get_singleton();")
+
     if class_name == "Object":
         result.append("\ttemplate <typename T>")
         result.append("\tstatic T *cast_to(Object *p_object);")

--- a/src/classes/low_level.cpp
+++ b/src/classes/low_level.cpp
@@ -35,6 +35,17 @@
 
 #include <godot_cpp/godot.hpp>
 
+// Unlike the classes above, `Engine` and `SceneTree` aren't always generated, since they may be left out of a build profile.
+// Only define `SceneTree::get_singleton()` when both of them are available, so that build profiles don't have to include them.
+#if __has_include(<godot_cpp/classes/engine.hpp>) && __has_include(<godot_cpp/classes/scene_tree.hpp>)
+#define GODOT_CPP_SCENE_TREE_SINGLETON
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+
+#include <godot_cpp/core/object.hpp>
+#endif
+
 namespace godot {
 Error XMLParser::_open_buffer(const uint8_t *p_buffer, size_t p_size) {
 	return (Error)::godot::gdextension_interface::xml_parser_open_buffer(_owner, p_buffer, p_size);
@@ -63,5 +74,11 @@ uint8_t *Image::ptrw() {
 const uint8_t *Image::ptr() {
 	return ::godot::gdextension_interface::image_ptr(_owner);
 }
+
+#ifdef GODOT_CPP_SCENE_TREE_SINGLETON
+SceneTree *SceneTree::get_singleton() {
+	return Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+}
+#endif
 
 } // namespace godot

--- a/test/build_profile.json
+++ b/test/build_profile.json
@@ -1,11 +1,13 @@
 {
 	"enabled_classes": [
 		"Control",
+		"Engine",
 		"InputEventKey",
 		"Label",
 		"MultiplayerAPI",
 		"MultiplayerPeer",
 		"OS",
+		"SceneTree",
 		"TileMap",
 		"TileSet",
 		"Tween",

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -279,6 +279,9 @@ func _ready():
 	# Test that we can access an engine singleton.
 	assert_equal(example.test_use_engine_singleton(), OS.get_name())
 
+	# Test that we can access the SceneTree singleton.
+	assert_equal(example.test_use_scene_tree_singleton(), true)
+
 	if godot_target_version["minor"] >= 4:
 		assert_equal(example.test_get_internal(1), 1)
 		assert_equal(example.test_get_internal(true), -1)

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -12,6 +12,7 @@
 #include <godot_cpp/classes/multiplayer_api.hpp>
 #include <godot_cpp/classes/multiplayer_peer.hpp>
 #include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
@@ -266,6 +267,7 @@ void Example::_bind_methods() {
 	GDVIRTUAL_BIND(_do_something_virtual_with_control, "control");
 
 	ClassDB::bind_method(D_METHOD("test_use_engine_singleton"), &Example::test_use_engine_singleton);
+	ClassDB::bind_method(D_METHOD("test_use_scene_tree_singleton"), &Example::test_use_scene_tree_singleton);
 
 	ClassDB::bind_method(D_METHOD("test_get_internal_class"), &Example::test_get_internal_class);
 
@@ -757,6 +759,11 @@ String Example::test_virtual_implemented_in_script(const String &p_name, int p_v
 
 String Example::test_use_engine_singleton() const {
 	return OS::get_singleton()->get_name();
+}
+
+bool Example::test_use_scene_tree_singleton() const {
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	return scene_tree != nullptr && scene_tree == get_tree();
 }
 
 String Example::test_library_path() {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -214,6 +214,7 @@ public:
 	GDVIRTUAL1(_do_something_virtual_with_control, Control *);
 
 	String test_use_engine_singleton() const;
+	bool test_use_scene_tree_singleton() const;
 
 	static String test_library_path();
 


### PR DESCRIPTION
Adds a `SceneTree::get_singleton()` to godot-cpp which mirrors the method available to modules in Godot core. SceneTree is not a registered engine singleton so I implemented it like it was suggested in the issue (thanks to @dsnopek):

    Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());

the declaration is injected into the generated header with a binding_generator.py specias case. I added a test method and assertion to the integration test.

Fixes #1597

## AI disclosure
I used claude to brainstorm then make sure I didn't miss any blind spots/repo conventions. All code was written and reviewed by me.