### PR TITLE
Use explicit encodings in the build scripts instead of locale-dependent defaults.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -336,7 +336,7 @@ def generate_gdextension_interface_loader(interface_filepath, output_dir):
     header_filename = include_gen_folder / "gdextension_interface_loader.hpp"
     source_filename = source_gen_folder / "gdextension_interface_loader.cpp"
 
-    with open(interface_filepath, "rt") as file:
+    with open(interface_filepath, "rt", encoding="utf-8") as file:
         data = json.load(file)
 
     functions_by_version = {}
@@ -657,9 +657,8 @@ def generate_builtin_bindings(api, output_dir, build_config):
 
     # Create a header to implement all builtin class vararg methods and be included in "variant.hpp".
     builtin_vararg_methods_header = include_gen_folder / "builtin_vararg_methods.hpp"
-    builtin_vararg_methods_header.open("w+").write(
-        generate_builtin_class_vararg_method_implements_header(api["builtin_classes"])
-    )
+    with builtin_vararg_methods_header.open("w+", encoding="utf-8") as vararg_methods_file:
+        vararg_methods_file.write(generate_builtin_class_vararg_method_implements_header(api["builtin_classes"]))
 
 
 def generate_builtin_class_vararg_method_implements_header(builtin_classes):

--- a/tools/header_builders.py
+++ b/tools/header_builders.py
@@ -4,7 +4,7 @@ import os.path
 ## See https://github.com/godotengine/godot/blob/master/glsl_builders.py
 def build_raw_header(source_filename: str, constant_name: str) -> None:
     # Read the source file content.
-    with open(source_filename, "r") as source_file:
+    with open(source_filename, "r", encoding="utf-8", newline="\n") as source_file:
         source_content = source_file.read()
         constant_name = constant_name.replace(".", "_")
         # Build header content using a C raw string literal.
@@ -18,7 +18,7 @@ def build_raw_header(source_filename: str, constant_name: str) -> None:
         )
         # Write the header to the provided file name with a ".gen.h" suffix.
         header_filename = f"{source_filename}.gen.h"
-        with open(header_filename, "w") as header_file:
+        with open(header_filename, "w", encoding="utf-8", newline="\n") as header_file:
             header_file.write(header_content)
 
 

--- a/tools/my_spawn.py
+++ b/tools/my_spawn.py
@@ -9,6 +9,7 @@ def exists(env):
 # http://www.scons.org/wiki/LongCmdLinesOnWin32
 def configure(env):
     import subprocess
+    import sys
 
     def mySubProcess(cmdline, env):
         # print "SPAWNED : " + cmdline
@@ -27,7 +28,7 @@ def configure(env):
         rv = proc.wait()
         if rv:
             print("=====")
-            print(err.decode("utf-8"))
+            print(err.decode(sys.stdout.encoding, errors="replace"))
             print("=====")
         return rv
 

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -57,9 +57,9 @@ def silence_msvc(env):
             if not caught and (is_cl and re_cl_capture.match(line)) or (not is_cl and re_link_capture.match(line)):
                 caught = True
                 try:
-                    with open(capture_path, "a", encoding=sys.stdout.encoding) as log:
+                    with open(capture_path, "a", encoding="utf-8") as log:
                         log.write(line + "\n")
-                except OSError:
+                except (OSError, UnicodeError):
                     print(f'WARNING: Failed to log captured line: "{line}".')
                 continue
             content += line + "\n"


### PR DESCRIPTION
fixed #2010 

Note on Windows: `open()` without an explicit `encoding` uses the ANSI code page (e.g. cp932 on Japanese Windows) rather than UTF-8, and `sys.stdout.encoding` follows the console code page, so text written and read with different defaults gets mixed encodings and can raise `UnicodeEncodeError`/`UnicodeDecodeError`. In text mode Python also translates `\n` to `\r\n` on write, which would change the contents of the generated raw string literals — hence `newline="\n"`.
