### PR TITLE
Sync `Memory` with godot upstream.

### DIFF
--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -60,35 +60,37 @@ namespace godot {
 
 class Wrapped;
 
-class Memory {
-	Memory();
+namespace Memory {
+constexpr size_t get_aligned_address(size_t p_address, size_t p_alignment) {
+	const size_t n_bytes_unaligned = p_address % p_alignment;
+	return (n_bytes_unaligned == 0) ? p_address : (p_address + p_alignment - n_bytes_unaligned);
+}
 
-public:
 #if defined(__MINGW32__) && !defined(__MINGW64__)
-	// Note: Using hardcoded value, since the value can end up different in different compile units on 32-bit windows
-	// due to a compiler bug (see GH-113145)
-	static constexpr size_t MAX_ALIGN = 16;
-	static_assert(MAX_ALIGN % alignof(max_align_t) == 0);
+// Note: Using hardcoded value, since the value can end up different in different compile units on 32-bit windows
+// due to a compiler bug (see GH-113145)
+static constexpr size_t MAX_ALIGN = 16;
+static_assert(MAX_ALIGN % alignof(max_align_t) == 0);
 #else
-	static constexpr size_t MAX_ALIGN = alignof(max_align_t);
+static constexpr size_t MAX_ALIGN = alignof(max_align_t);
 #endif
 
-	// Alignment:  ↓ max_align_t        ↓ uint64_t          ↓ MAX_ALIGN
-	//             ┌─────────────────┬──┬────────────────┬──┬───────────...
-	//             │ uint64_t        │░░│ uint64_t       │░░│ T[]
-	//             │ alloc size      │░░│ element count  │░░│ data
-	//             └─────────────────┴──┴────────────────┴──┴───────────...
-	// Offset:     ↑ SIZE_OFFSET        ↑ ELEMENT_OFFSET    ↑ DATA_OFFSET
-	// Note: "alloc size" is used and set by the engine and is never accessed or changed for the extension.
+// Alignment:  ↓ max_align_t        ↓ uint64_t          ↓ MAX_ALIGN
+//             ┌─────────────────┬──┬────────────────┬──┬───────────...
+//             │ uint64_t        │░░│ uint64_t       │░░│ T[]
+//             │ alloc size      │░░│ element count  │░░│ data
+//             └─────────────────┴──┴────────────────┴──┴───────────...
+// Offset:     ↑ SIZE_OFFSET        ↑ ELEMENT_OFFSET    ↑ DATA_OFFSET
+// Note: "alloc size" is used and set by the engine and is never accessed or changed for the extension.
 
-	static constexpr size_t SIZE_OFFSET = 0;
-	static constexpr size_t ELEMENT_OFFSET = ((SIZE_OFFSET + sizeof(uint64_t)) % alignof(uint64_t) == 0) ? (SIZE_OFFSET + sizeof(uint64_t)) : ((SIZE_OFFSET + sizeof(uint64_t)) + alignof(uint64_t) - ((SIZE_OFFSET + sizeof(uint64_t)) % alignof(uint64_t)));
-	static constexpr size_t DATA_OFFSET = ((ELEMENT_OFFSET + sizeof(uint64_t)) % MAX_ALIGN == 0) ? (ELEMENT_OFFSET + sizeof(uint64_t)) : ((ELEMENT_OFFSET + sizeof(uint64_t)) + MAX_ALIGN - ((ELEMENT_OFFSET + sizeof(uint64_t)) % MAX_ALIGN));
+inline constexpr size_t SIZE_OFFSET = 0;
+inline constexpr size_t ELEMENT_OFFSET = get_aligned_address(SIZE_OFFSET + sizeof(uint64_t), alignof(uint64_t));
+inline constexpr size_t DATA_OFFSET = get_aligned_address(ELEMENT_OFFSET + sizeof(uint64_t), MAX_ALIGN);
 
-	static void *alloc_static(size_t p_bytes, bool p_pad_align = false);
-	static void *realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align = false);
-	static void free_static(void *p_ptr, bool p_pad_align = false);
-};
+void *alloc_static(size_t p_bytes, bool p_pad_align = false);
+void *realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align = false);
+void free_static(void *p_ptr, bool p_pad_align = false);
+}; //namespace Memory
 
 template <typename T, std::enable_if_t<!std::is_base_of<::godot::Wrapped, T>::value, bool> = true>
 _ALWAYS_INLINE_ void _pre_initialize() {}


### PR DESCRIPTION
Trying to get on top of the v10 release now by syncing all the templates 😅

My work was basically: paste `Memory` from Godot upstream, then examine and fix differences in the diff view.