### PR TITLE
Add `_err_print_script_error` helper methods

### DIFF
--- a/gdextension/gdextension_interface.json
+++ b/gdextension/gdextension_interface.json
@@ -3975,6 +3975,101 @@
             "since": "4.1"
         },
         {
+            "name": "print_script_error",
+            "arguments": [
+                {
+                    "name": "p_description",
+                    "type": "const char*",
+                    "description": [
+                        "The code triggering the error."
+                    ]
+                },
+                {
+                    "name": "p_function",
+                    "type": "const char*",
+                    "description": [
+                        "The function name where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_file",
+                    "type": "const char*",
+                    "description": [
+                        "The file where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_line",
+                    "type": "int32_t",
+                    "description": [
+                        "The line where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_editor_notify",
+                    "type": "GDExtensionBool",
+                    "description": [
+                        "Whether or not to notify the editor."
+                    ]
+                }
+            ],
+            "description": [
+                "Logs a script error to Godot's built-in debugger and to the OS terminal."
+            ],
+            "since": "4.8"
+        },
+        {
+            "name": "print_script_error_with_message",
+            "arguments": [
+                {
+                    "name": "p_description",
+                    "type": "const char*",
+                    "description": [
+                        "The code triggering the error."
+                    ]
+                },
+                {
+                    "name": "p_message",
+                    "type": "const char*",
+                    "description": [
+                        "The message to show along with the error."
+                    ]
+                },
+                {
+                    "name": "p_function",
+                    "type": "const char*",
+                    "description": [
+                        "The function name where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_file",
+                    "type": "const char*",
+                    "description": [
+                        "The file where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_line",
+                    "type": "int32_t",
+                    "description": [
+                        "The line where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_editor_notify",
+                    "type": "GDExtensionBool",
+                    "description": [
+                        "Whether or not to notify the editor."
+                    ]
+                }
+            ],
+            "description": [
+                "Logs a script error with a message to Godot's built-in debugger and to the OS terminal."
+            ],
+            "since": "4.8"
+        },
+        {
             "name": "print_warning",
             "arguments": [
                 {

--- a/include/godot_cpp/core/error_macros.hpp
+++ b/include/godot_cpp/core/error_macros.hpp
@@ -46,6 +46,12 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_editor_notify = false, bool p_is_warning = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool p_editor_notify = false, bool p_fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool p_editor_notify = false, bool p_fatal = false);
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const char *p_error, bool p_editor_notify = false);
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const String &p_error, bool p_editor_notify = false);
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, bool p_editor_notify = false);
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const char *p_message, bool p_editor_notify = false);
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const String &p_message, bool p_editor_notify = false);
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_editor_notify = false);
 void _err_flush_stdout();
 
 } // namespace godot

--- a/src/core/error_macros.cpp
+++ b/src/core/error_macros.cpp
@@ -79,6 +79,30 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	_err_print_index_error(p_function, p_file, p_line, p_index, p_size, p_index_str, p_size_str, p_message.utf8().get_data(), p_editor_notify, p_fatal);
 }
 
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const char *p_error, bool p_editor_notify) {
+	::godot::gdextension_interface::print_script_error(p_error, p_function, p_file, p_line, p_editor_notify);
+}
+
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const String &p_error, bool p_editor_notify) {
+	::godot::gdextension_interface::print_script_error(p_error.utf8().get_data(), p_function, p_file, p_line, p_editor_notify);
+}
+
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, bool p_editor_notify) {
+	::godot::gdextension_interface::print_script_error_with_message(p_error, p_message, p_function, p_file, p_line, p_editor_notify);
+}
+
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const char *p_message, bool p_editor_notify) {
+	::godot::gdextension_interface::print_script_error_with_message(p_error.utf8().get_data(), p_message, p_function, p_file, p_line, p_editor_notify);
+}
+
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const String &p_message, bool p_editor_notify) {
+	::godot::gdextension_interface::print_script_error_with_message(p_error, p_message.utf8().get_data(), p_function, p_file, p_line, p_editor_notify);
+}
+
+void _err_print_script_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_editor_notify) {
+	::godot::gdextension_interface::print_script_error_with_message(p_error.utf8().get_data(), p_message.utf8().get_data(), p_function, p_file, p_line, p_editor_notify);
+}
+
 void _err_flush_stdout() {
 	fflush(stdout);
 }


### PR DESCRIPTION
@dsnopek as discussed on RChat, here's the implementations for the "print_script_error" APIs