### PR TITLE
Fix `_THREAD_SAFE_CLASS_` and related macros

### DIFF
--- a/include/godot_cpp/core/mutex_lock.hpp
+++ b/include/godot_cpp/core/mutex_lock.hpp
@@ -35,22 +35,22 @@
 namespace godot {
 
 class MutexLock {
-	const Mutex &mutex;
+	const Ref<Mutex> &mutex;
 
 public:
-	_ALWAYS_INLINE_ explicit MutexLock(const Mutex &p_mutex) :
+	_ALWAYS_INLINE_ explicit MutexLock(const Ref<Mutex> &p_mutex) :
 			mutex(p_mutex) {
-		const_cast<Mutex *>(&mutex)->lock();
+		const_cast<Mutex *>(*mutex)->lock();
 	}
 
 	_ALWAYS_INLINE_ ~MutexLock() {
-		const_cast<Mutex *>(&mutex)->unlock();
+		const_cast<Mutex *>(*mutex)->unlock();
 	}
 };
 
-#define _THREAD_SAFE_CLASS_ mutable Mutex _thread_safe_;
+#define _THREAD_SAFE_CLASS_ mutable Ref<Mutex> _thread_safe_ = Ref<Mutex>(memnew(Mutex));
 #define _THREAD_SAFE_METHOD_ MutexLock _thread_safe_method_(_thread_safe_);
-#define _THREAD_SAFE_LOCK_ _thread_safe_.lock();
-#define _THREAD_SAFE_UNLOCK_ _thread_safe_.unlock();
+#define _THREAD_SAFE_LOCK_ _thread_safe_->lock();
+#define _THREAD_SAFE_UNLOCK_ _thread_safe_->unlock();
 
 } // namespace godot

--- a/test/build_profile.json
+++ b/test/build_profile.json
@@ -5,6 +5,7 @@
 		"Label",
 		"MultiplayerAPI",
 		"MultiplayerPeer",
+		"Mutex",
 		"OS",
 		"TileMap",
 		"TileSet",

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -310,6 +310,12 @@ func _ready():
 		var przykład = ClassDB.instantiate("ExamplePrzykład")
 		assert_equal(przykład.get_the_word(), "słowo to przykład")
 
+	# Test call some methods on a thread safe class.
+	var example_thread_safe = ExampleThreadSafeClass.new()
+	assert_equal(example_thread_safe.test(), 123)
+	assert_equal(example_thread_safe.test_const(), 456)
+	assert_equal(example_thread_safe.test_manual(), 789)
+
 	exit_with_status()
 
 func _on_Example_custom_signal(signal_name, value):

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -816,3 +816,25 @@ void ExampleInternal::_bind_methods() {
 int ExampleInternal::get_the_answer() const {
 	return 42;
 }
+
+void ExampleThreadSafeClass::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("test"), &ExampleThreadSafeClass::test);
+	ClassDB::bind_method(D_METHOD("test_const"), &ExampleThreadSafeClass::test_const);
+	ClassDB::bind_method(D_METHOD("test_manual"), &ExampleThreadSafeClass::test_manual);
+}
+
+int ExampleThreadSafeClass::test() {
+	_THREAD_SAFE_METHOD_
+	return 123;
+}
+
+int ExampleThreadSafeClass::test_const() const {
+	_THREAD_SAFE_METHOD_
+	return 456;
+}
+
+int ExampleThreadSafeClass::test_manual() {
+	_THREAD_SAFE_LOCK_
+	_THREAD_SAFE_UNLOCK_
+	return 789;
+}

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -21,6 +21,7 @@
 #include <godot_cpp/classes/tile_set.hpp>
 #include <godot_cpp/classes/tween.hpp>
 #include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/core/mutex_lock.hpp>
 #include <godot_cpp/variant/variant.hpp>
 #include <godot_cpp/variant/variant_internal.hpp>
 
@@ -312,4 +313,18 @@ protected:
 
 public:
 	int get_the_answer() const;
+};
+
+class ExampleThreadSafeClass : public RefCounted {
+	GDCLASS(ExampleThreadSafeClass, RefCounted);
+
+	_THREAD_SAFE_CLASS_
+
+protected:
+	static void _bind_methods();
+
+public:
+	int test();
+	int test_const() const;
+	int test_manual();
 };

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -32,6 +32,7 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_RUNTIME_CLASS(ExampleRuntime);
 	GDREGISTER_CLASS(ExamplePrzykład);
 	GDREGISTER_INTERNAL_CLASS(ExampleInternal);
+	GDREGISTER_CLASS(ExampleThreadSafeClass);
 }
 
 void uninitialize_example_module(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/2020

This also adds some tests, so hopefully, we won't break it again later