### PR TITLE
Delete `operator=(const m_class &p_rval)` on wrapper classes

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -199,7 +199,7 @@ struct EngineClassRegistration {
 // every line of the macro different
 #define GDCLASS(m_class, m_inherits) \
 private: \
-	void operator=(const m_class & /*p_rval*/) {} \
+	void operator=(const m_class &p_rval) = delete; \
 	friend class ::godot::ClassDB; \
 	friend class ::godot::Wrapped; \
 \
@@ -428,7 +428,7 @@ private:
 #define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits) \
 private: \
 	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper; \
-	void operator=(const m_class &p_rval) {} \
+	void operator=(const m_class &p_rval) = delete; \
 	friend class ::godot::ClassDB; \
 	friend class ::godot::Wrapped; \
 \


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1995

This seems like it'd be OK, given that the previous `operator=(const m_class &p_rval)` did nothing, and we don't really want wrapper classes to be copyable by value (they should always be pointers)

But I'm not 100% sure that I understand the full implications - it'd be great to get feedback from someone with stronger C++ knowledge!

FYI, Godot's `Object` also declares an empty `operator=(const m_class &p_rval)` - if this makes sense in godot-cpp, maybe it should also be deleted in Godot as well?