### PR TITLE
Fix VARIANT_ENUM_CAST to support enum class (`master`)

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -56,7 +56,7 @@ namespace godot {
 		} \
 		typedef int64_t EncodeT; \
 		_FORCE_INLINE_ static void encode(m_enum p_val, void *p_ptr) { \
-			*reinterpret_cast<int64_t *>(p_ptr) = p_val; \
+			*reinterpret_cast<int64_t *>(p_ptr) = static_cast<int64_t>(p_val); \
 		} \
 	}; \
 	}
@@ -77,7 +77,7 @@ namespace godot {
 		} \
 		typedef int64_t EncodeT; \
 		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, void *p_ptr) { \
-			*reinterpret_cast<int64_t *>(p_ptr) = p_val; \
+			*reinterpret_cast<int64_t *>(p_ptr) = static_cast<int64_t>(p_val); \
 		} \
 	}; \
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1984

I didn't notice that the branch was set to `4.5` when I merged https://github.com/godotengine/godot-cpp/pull/1914

This PR just takes those changes and applies them to `master` (like they should have been from the start)