### PR TITLE
Add `Mutex` from upstream Godot, and put the upstream `Mutex` into `CoreBind`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1792,7 +1792,10 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
         result.append("#include <godot_cpp/core/binder_common.hpp>")
         result.append("")
 
-    result.append("namespace godot {")
+    if class_name == "Mutex":
+        result.append("namespace godot::CoreBind {")
+    else:
+        result.append("namespace godot {")
     result.append("")
 
     for type_name in used_classes:
@@ -2099,7 +2102,10 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
 
         result.append("")
 
-    result.append("namespace godot {")
+    if class_name == "Mutex":
+        result.append("namespace godot::CoreBind {")
+    else:
+        result.append("namespace godot {")
     result.append("")
 
     if is_singleton:

--- a/include/godot_cpp/templates/mutex.hpp
+++ b/include/godot_cpp/templates/mutex.hpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  mutex_lock.hpp                                                        */
+/*  mutex.hpp                                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,27 +30,108 @@
 
 #pragma once
 
-#include <godot_cpp/classes/mutex.hpp>
+#include <godot_cpp/core/defs.hpp>
+
+#ifdef MINGW_ENABLED
+#define MINGW_STDTHREAD_REDUNDANCY_WARNING
+#include <thirdparty/mingw-std-threads/mingw.mutex.h>
+#define THREADING_NAMESPACE mingw_stdthread
+#else
+#include <mutex>
+#define THREADING_NAMESPACE std
+#endif
 
 namespace godot {
 
-class MutexLock {
-	const Mutex &mutex;
+#ifdef THREADS_ENABLED
+
+template <typename MutexT>
+class MutexLock;
+
+template <typename StdMutexT>
+class MutexImpl {
+	friend class MutexLock<MutexImpl<StdMutexT>>;
+
+	using StdMutexType = StdMutexT;
+
+	mutable StdMutexT mutex;
 
 public:
-	_ALWAYS_INLINE_ explicit MutexLock(const Mutex &p_mutex) :
-			mutex(p_mutex) {
-		const_cast<Mutex *>(&mutex)->lock();
+	_ALWAYS_INLINE_ void lock() const {
+		mutex.lock();
 	}
 
-	_ALWAYS_INLINE_ ~MutexLock() {
-		const_cast<Mutex *>(&mutex)->unlock();
+	_ALWAYS_INLINE_ void unlock() const {
+		mutex.unlock();
+	}
+
+	_ALWAYS_INLINE_ bool try_lock() const {
+		return mutex.try_lock();
 	}
 };
+
+template <typename MutexT>
+class [[nodiscard]] MutexLock {
+	mutable THREADING_NAMESPACE::unique_lock<typename MutexT::StdMutexType> lock;
+
+public:
+	explicit MutexLock(const MutexT &p_mutex) :
+			lock(p_mutex.mutex) {}
+
+	// Clarification: all the funny syntax is needed so this function exists only for binary mutexes.
+	template <typename T = MutexT>
+	_ALWAYS_INLINE_ THREADING_NAMESPACE::unique_lock<THREADING_NAMESPACE::mutex> &_get_lock(
+			typename std::enable_if<std::is_same<T, THREADING_NAMESPACE::mutex>::value> * = nullptr) const {
+		return lock;
+	}
+
+	_ALWAYS_INLINE_ void temp_relock() const {
+		lock.lock();
+	}
+
+	_ALWAYS_INLINE_ void temp_unlock() const {
+		lock.unlock();
+	}
+
+	// TODO: Implement a `try_temp_relock` if needed (will also need a dummy method below).
+};
+
+using Mutex = MutexImpl<THREADING_NAMESPACE::recursive_mutex>; // Recursive, for general use
+using BinaryMutex = MutexImpl<THREADING_NAMESPACE::mutex>; // Non-recursive, handle with care
 
 #define _THREAD_SAFE_CLASS_ mutable Mutex _thread_safe_;
 #define _THREAD_SAFE_METHOD_ MutexLock _thread_safe_method_(_thread_safe_);
 #define _THREAD_SAFE_LOCK_ _thread_safe_.lock();
 #define _THREAD_SAFE_UNLOCK_ _thread_safe_.unlock();
+
+#else // No threads.
+
+class MutexImpl {
+	mutable THREADING_NAMESPACE::mutex mutex;
+
+public:
+	void lock() const {}
+	void unlock() const {}
+	bool try_lock() const { return true; }
+};
+
+template <typename MutexT>
+class [[nodiscard]] MutexLock {
+public:
+	MutexLock(const MutexT &p_mutex) {}
+
+	void temp_relock() const {}
+	void temp_unlock() const {}
+};
+
+using Mutex = MutexImpl;
+using BinaryMutex = MutexImpl;
+
+#define _THREAD_SAFE_CLASS_
+#define _THREAD_SAFE_METHOD_
+#define _THREAD_SAFE_LOCK_
+#define _THREAD_SAFE_UNLOCK_
+
+#endif // THREADS_ENABLED
 
 } // namespace godot

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -310,6 +310,12 @@ func _ready():
 		var przykład = ClassDB.instantiate("ExamplePrzykład")
 		assert_equal(przykład.get_the_word(), "słowo to przykład")
 
+	# Test call some methods on a thread safe class.
+	var example_thread_safe = ExampleThreadSafeClass.new()
+	assert_equal(example_thread_safe.test(), 123)
+	assert_equal(example_thread_safe.test_const(), 456)
+	assert_equal(example_thread_safe.test_manual(), 789)
+
 	exit_with_status()
 
 func _on_Example_custom_signal(signal_name, value):

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -816,3 +816,25 @@ void ExampleInternal::_bind_methods() {
 int ExampleInternal::get_the_answer() const {
 	return 42;
 }
+
+void ExampleThreadSafeClass::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("test"), &ExampleThreadSafeClass::test);
+	ClassDB::bind_method(D_METHOD("test_const"), &ExampleThreadSafeClass::test_const);
+	ClassDB::bind_method(D_METHOD("test_manual"), &ExampleThreadSafeClass::test_manual);
+}
+
+int ExampleThreadSafeClass::test() {
+	_THREAD_SAFE_METHOD_
+	return 123;
+}
+
+int ExampleThreadSafeClass::test_const() const {
+	_THREAD_SAFE_METHOD_
+	return 456;
+}
+
+int ExampleThreadSafeClass::test_manual() {
+	_THREAD_SAFE_LOCK_
+	_THREAD_SAFE_UNLOCK_
+	return 789;
+}

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -21,6 +21,7 @@
 #include <godot_cpp/classes/tile_set.hpp>
 #include <godot_cpp/classes/tween.hpp>
 #include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/templates/mutex.hpp>
 #include <godot_cpp/variant/variant.hpp>
 #include <godot_cpp/variant/variant_internal.hpp>
 
@@ -312,4 +313,18 @@ protected:
 
 public:
 	int get_the_answer() const;
+};
+
+class ExampleThreadSafeClass : public RefCounted {
+	GDCLASS(ExampleThreadSafeClass, RefCounted);
+
+	_THREAD_SAFE_CLASS_
+
+protected:
+	static void _bind_methods();
+
+public:
+	int test();
+	int test_const() const;
+	int test_manual();
 };

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -32,6 +32,7 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_RUNTIME_CLASS(ExampleRuntime);
 	GDREGISTER_CLASS(ExamplePrzykład);
 	GDREGISTER_INTERNAL_CLASS(ExampleInternal);
+	GDREGISTER_CLASS(ExampleThreadSafeClass);
 }
 
 void uninitialize_example_module(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
- Should fix https://github.com/godotengine/godot-cpp/issues/2020
- Alternative to #2026 (test copied from there)

As mentioned in #2026, using the bound mutex is suboptimal because it's heap allocated (must be used with `Ref`) and unnecessarily slow.
Instead, this syncs the upstream `Mutex`, and moves the exposed upstream one into `CoreBind`, matching upstream itself.