### PR TITLE
Ensure `Variant`'s are 8-byte aligned

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -45,7 +45,7 @@ namespace godot {
 class ObjectID;
 
 class Variant {
-	uint8_t opaque[GODOT_CPP_VARIANT_SIZE]{ 0 };
+	alignas(8) uint8_t opaque[GODOT_CPP_VARIANT_SIZE]{ 0 };
 
 	friend class GDExtensionBinding;
 	friend class MethodBind;


### PR DESCRIPTION
This got missed in https://github.com/godotengine/godot-cpp/pull/1958 because `variant.hpp` is hand-written rather than generated