### PR TITLE
Don't end ext_wrappers.gen.inc macros with a backslash-newline

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -11,7 +11,7 @@ from make_interface_header import generate_gdextension_interface_header
 def generate_mod_version(argcount, const=False, returns=False):
     s = """
 #define MODBIND$VER($RETTYPE m_name$ARG) \\
-virtual $RETVAL _##m_name($FUNCARGS) $CONST override; \\
+virtual $RETVAL _##m_name($FUNCARGS) $CONST override;
 """
     sproto = str(argcount)
     if returns:


### PR DESCRIPTION
Fixes warning when including ext_wrappers.gen.inc:

```
godot-cpp/gen/include/godot_cpp/core/ext_wrappers.gen.inc:181:148: warning: backslash-newline at end of file
```