### PR TITLE
SCons: Add `p` alias for `platform`

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -243,7 +243,7 @@ def options(opts, env):
 
     opts.Add(
         EnumVariable(
-            key="platform",
+            key=("platform", "p"),
             help="Target platform",
             default=env.get("platform", default_platform),
             allowed_values=platforms + custom_platforms,


### PR DESCRIPTION
For consistency with the Godot SCons option.

I don't compile godot-cpp extensions too often, but whenever I do I trip on the lack of `p` alias for `platform`, like we have in the main Godot SCons buildsystem.

Help output:
```
platform: Target platform (linux|macos|windows|android|ios|web)
    default: linux
    actual: linux
    aliases: ['p']
```